### PR TITLE
Implement pipeline/04_ingest_qdrant.py

### DIFF
--- a/pipeline/04_ingest_qdrant.py
+++ b/pipeline/04_ingest_qdrant.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import numpy as np
+from dataclasses import dataclass
+
+
+@dataclass
+class PointStruct:
+    id: int
+    vector: list
+    payload: dict
+
+
+def build_points(embeddings: np.ndarray, metadata: list) -> list:
+    return [
+        PointStruct(
+            id=i,
+            vector=embeddings[i].tolist(),
+            payload={**metadata[i], "thumbnail_url": None},
+        )
+        for i in range(len(embeddings))
+    ]
+
+
+def setup_collection(client, collection_name: str):
+    from qdrant_client.http.models import Distance, VectorParams
+
+    client.recreate_collection(
+        collection_name=collection_name,
+        vectors_config=VectorParams(size=384, distance=Distance.COSINE),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ingest embeddings into Qdrant.")
+    parser.add_argument("--qdrant-url", default="http://localhost:6333")
+    args = parser.parse_args()
+
+    from qdrant_client import QdrantClient
+    from tqdm import tqdm
+
+    embeddings = np.load("data/embeddings/embeddings.npy")
+    with open("data/embeddings/metadata.json") as f:
+        metadata = json.load(f)
+
+    client = QdrantClient(url=args.qdrant_url)
+    setup_collection(client, "movies")
+    points = build_points(embeddings, metadata)
+
+    batch_size = 256
+    for i in tqdm(range(0, len(points), batch_size)):
+        batch = points[i : i + batch_size]
+        client.upsert(collection_name="movies", points=batch)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,3 +1,4 @@
 transformers==4.39.3
 torch>=2.0.0
 onnxruntime==1.17.3
+qdrant-client


### PR DESCRIPTION
## Summary
Creates `pipeline/04_ingest_qdrant.py` that exposes `build_points` and `setup_collection` module-level functions and a `main()` entry point for ingesting embeddings into Qdrant.

## Changes
- `pipeline/04_ingest_qdrant.py` — new script with `PointStruct` dataclass, `build_points`, `setup_collection`, and `main()` with `--qdrant-url` CLI arg
- `pipeline/requirements.txt` — added `qdrant-client`

## Verification
All acceptance criteria from #8 verified before opening this PR.

Closes #8