### PR TITLE
Integration tests: Python offline pipeline scripts (steps 1–5)

### DIFF
--- a/pipeline/01_download_corpus.py
+++ b/pipeline/01_download_corpus.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Download CMU Movie Summary Corpus to data/raw/."""
+
+import pathlib
+import sys
+import tarfile
+import urllib.request
+
+CORPUS_URL = "https://www.cs.cmu.edu/~ark/personas/data/MovieSummaries.tar.gz"
+RAW_DIR = pathlib.Path("data/raw")
+METADATA_PATH = RAW_DIR / "movie.metadata.tsv"
+SUMMARIES_PATH = RAW_DIR / "plot_summaries.txt"
+
+_EXTRACT_FILES = {"movie.metadata.tsv", "plot_summaries.txt"}
+
+
+def is_already_downloaded() -> bool:
+    return METADATA_PATH.exists() and SUMMARIES_PATH.exists()
+
+
+def download_and_extract(url: str, dest_dir: pathlib.Path) -> None:
+    from tqdm import tqdm
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    archive = dest_dir / "MovieSummaries.tar.gz"
+
+    with urllib.request.urlopen(url) as response:
+        total = int(response.headers.get("Content-Length", 0)) or None
+        with tqdm(total=total, unit="B", unit_scale=True, desc="Downloading") as bar:
+            with open(archive, "wb") as f:
+                while True:
+                    chunk = response.read(65536)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+                    bar.update(len(chunk))
+
+    with tarfile.open(archive) as tar:
+        for member in tar.getmembers():
+            fname = pathlib.Path(member.name).name
+            if fname in _EXTRACT_FILES:
+                member.name = fname
+                tar.extract(member, path=dest_dir)
+
+    archive.unlink()
+
+
+def main():
+    if is_already_downloaded():
+        print("Corpus already downloaded, skipping.", flush=True)
+        sys.exit(0)
+
+    print(f"Downloading corpus from {CORPUS_URL} ...", flush=True)
+    download_and_extract(CORPUS_URL, RAW_DIR)
+    print(f"Done. Files written to {RAW_DIR}.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/tests/conftest.py
+++ b/pipeline/tests/conftest.py
@@ -1,0 +1,121 @@
+"""
+Shared fixtures and stubs for pipeline unit tests.
+
+Stubs packages not installed in the test environment (tritonclient, tqdm,
+qdrant_client) so tests can import pipeline scripts without those deps.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _install_stubs():
+    # torch
+    if "torch" not in sys.modules:
+        torch_mod = types.ModuleType("torch")
+        torch_nn = types.ModuleType("torch.nn")
+        torch_onnx = types.ModuleType("torch.onnx")
+
+        class _Module:
+            def __init__(self): pass
+
+        torch_nn.Module = _Module
+        torch_onnx.export = MagicMock()
+        torch_mod.nn = torch_nn
+        torch_mod.onnx = torch_onnx
+        torch_mod.zeros_like = MagicMock(return_value=MagicMock())
+        sys.modules["torch"] = torch_mod
+        sys.modules["torch.nn"] = torch_nn
+        sys.modules["torch.onnx"] = torch_onnx
+
+    # transformers
+    if "transformers" not in sys.modules:
+        transformers_mod = types.ModuleType("transformers")
+        transformers_mod.AutoTokenizer = MagicMock
+        transformers_mod.AutoModel = MagicMock
+        sys.modules["transformers"] = transformers_mod
+
+    # onnxruntime
+    if "onnxruntime" not in sys.modules:
+        ort_mod = types.ModuleType("onnxruntime")
+        ort_mod.InferenceSession = MagicMock
+        sys.modules["onnxruntime"] = ort_mod
+
+    # qdrant_client
+    if "qdrant_client" not in sys.modules:
+        qdrant_client = types.ModuleType("qdrant_client")
+        qdrant_http = types.ModuleType("qdrant_client.http")
+        qdrant_http_models = types.ModuleType("qdrant_client.http.models")
+        qdrant_models = types.ModuleType("qdrant_client.models")
+
+        class Distance:
+            COSINE = "Cosine"
+
+        class VectorParams:
+            def __init__(self, size, distance):
+                self.size = size
+                self.distance = distance
+
+        qdrant_http_models.Distance = Distance
+        qdrant_http_models.VectorParams = VectorParams
+        qdrant_http_models.PointStruct = MagicMock
+
+        qdrant_client.QdrantClient = MagicMock
+        qdrant_client.http = qdrant_http
+        qdrant_http.models = qdrant_http_models
+
+        sys.modules["qdrant_client"] = qdrant_client
+        sys.modules["qdrant_client.http"] = qdrant_http
+        sys.modules["qdrant_client.http.models"] = qdrant_http_models
+        sys.modules["qdrant_client.models"] = qdrant_models
+
+    # tritonclient
+    if "tritonclient" not in sys.modules:
+        tritonclient = types.ModuleType("tritonclient")
+        tritonclient_grpc = types.ModuleType("tritonclient.grpc")
+        tritonclient_grpc.InferenceServerClient = MagicMock
+        tritonclient_grpc.InferInput = MagicMock
+        tritonclient_grpc.InferRequestedOutput = MagicMock
+        sys.modules["tritonclient"] = tritonclient
+        sys.modules["tritonclient.grpc"] = tritonclient_grpc
+
+    # tqdm
+    if "tqdm" not in sys.modules:
+        tqdm_mod = types.ModuleType("tqdm")
+        tqdm_auto = types.ModuleType("tqdm.auto")
+
+        class _FakeTqdm:
+            def __init__(self, iterable=None, **kwargs):
+                self._iterable = iterable or []
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+            def __iter__(self): return iter(self._iterable)
+            def update(self, n=1): pass
+
+        tqdm_mod.tqdm = _FakeTqdm
+        tqdm_auto.tqdm = _FakeTqdm
+        sys.modules["tqdm"] = tqdm_mod
+        sys.modules["tqdm.auto"] = tqdm_auto
+
+
+_install_stubs()
+
+
+@pytest.fixture(scope="session")
+def pipeline_loader():
+    """Load a pipeline script by filename and return it as a module."""
+    scripts_dir = Path(__file__).parent.parent
+
+    def _load(filename):
+        path = scripts_dir / filename
+        spec = importlib.util.spec_from_file_location(filename, path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    return _load

--- a/pipeline/tests/test_01_download_corpus.py
+++ b/pipeline/tests/test_01_download_corpus.py
@@ -1,0 +1,115 @@
+"""Tests for pipeline/01_download_corpus.py."""
+
+import io
+import tarfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mod(pipeline_loader):
+    return pipeline_loader("01_download_corpus.py")
+
+
+# ---------------------------------------------------------------------------
+# is_already_downloaded
+# ---------------------------------------------------------------------------
+
+class TestIsAlreadyDownloaded:
+    def test_true_when_both_files_exist(self, mod, tmp_path, monkeypatch):
+        metadata = tmp_path / "movie.metadata.tsv"
+        summaries = tmp_path / "plot_summaries.txt"
+        metadata.write_text("data")
+        summaries.write_text("data")
+        monkeypatch.setattr(mod, "METADATA_PATH", metadata)
+        monkeypatch.setattr(mod, "SUMMARIES_PATH", summaries)
+        assert mod.is_already_downloaded() is True
+
+    def test_false_when_metadata_missing(self, mod, tmp_path, monkeypatch):
+        metadata = tmp_path / "movie.metadata.tsv"
+        summaries = tmp_path / "plot_summaries.txt"
+        summaries.write_text("data")
+        monkeypatch.setattr(mod, "METADATA_PATH", metadata)
+        monkeypatch.setattr(mod, "SUMMARIES_PATH", summaries)
+        assert mod.is_already_downloaded() is False
+
+    def test_false_when_summaries_missing(self, mod, tmp_path, monkeypatch):
+        metadata = tmp_path / "movie.metadata.tsv"
+        summaries = tmp_path / "plot_summaries.txt"
+        metadata.write_text("data")
+        monkeypatch.setattr(mod, "METADATA_PATH", metadata)
+        monkeypatch.setattr(mod, "SUMMARIES_PATH", summaries)
+        assert mod.is_already_downloaded() is False
+
+    def test_false_when_both_missing(self, mod, tmp_path, monkeypatch):
+        monkeypatch.setattr(mod, "METADATA_PATH", tmp_path / "movie.metadata.tsv")
+        monkeypatch.setattr(mod, "SUMMARIES_PATH", tmp_path / "plot_summaries.txt")
+        assert mod.is_already_downloaded() is False
+
+
+# ---------------------------------------------------------------------------
+# download_and_extract
+# ---------------------------------------------------------------------------
+
+def _make_tar_gz(files: dict) -> bytes:
+    """Build an in-memory .tar.gz with filename → bytes content."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name=f"MovieSummaries/{name}")
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _mock_response(tar_bytes: bytes) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.read.side_effect = [tar_bytes, b""]
+    mock_resp.headers.get.return_value = str(len(tar_bytes))
+    return mock_resp
+
+
+class TestDownloadAndExtract:
+    def test_extracts_metadata_and_summaries(self, mod, tmp_path):
+        tar_bytes = _make_tar_gz({
+            "movie.metadata.tsv": b"111\tx\tCast Away\n",
+            "plot_summaries.txt": b"111\tSummary text\n",
+        })
+        with patch.object(mod.urllib.request, "urlopen", return_value=_mock_response(tar_bytes)):
+            mod.download_and_extract("http://fake-url", tmp_path)
+
+        assert (tmp_path / "movie.metadata.tsv").read_bytes() == b"111\tx\tCast Away\n"
+        assert (tmp_path / "plot_summaries.txt").read_bytes() == b"111\tSummary text\n"
+
+    def test_archive_removed_after_extraction(self, mod, tmp_path):
+        tar_bytes = _make_tar_gz({
+            "movie.metadata.tsv": b"data\n",
+            "plot_summaries.txt": b"data\n",
+        })
+        with patch.object(mod.urllib.request, "urlopen", return_value=_mock_response(tar_bytes)):
+            mod.download_and_extract("http://fake-url", tmp_path)
+
+        assert not (tmp_path / "MovieSummaries.tar.gz").exists()
+
+
+# ---------------------------------------------------------------------------
+# main — idempotency
+# ---------------------------------------------------------------------------
+
+class TestMainIdempotent:
+    def test_exits_early_when_already_downloaded(self, mod):
+        with patch.object(mod, "is_already_downloaded", return_value=True), \
+             patch.object(mod, "download_and_extract") as mock_dl, \
+             patch("sys.exit", side_effect=SystemExit(0)):
+            with pytest.raises(SystemExit):
+                mod.main()
+        mock_dl.assert_not_called()
+
+    def test_calls_download_when_not_present(self, mod):
+        with patch.object(mod, "is_already_downloaded", return_value=False), \
+             patch.object(mod, "download_and_extract") as mock_dl:
+            mod.main()
+        mock_dl.assert_called_once()

--- a/pipeline/tests/test_02_export_model.py
+++ b/pipeline/tests/test_02_export_model.py
@@ -1,0 +1,53 @@
+"""Tests for pipeline/02_export_model.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mod(pipeline_loader):
+    return pipeline_loader("02_export_model.py")
+
+
+# ---------------------------------------------------------------------------
+# _ModelWrapper
+# ---------------------------------------------------------------------------
+
+class TestModelWrapper:
+    def test_forward_calls_model_with_correct_kwargs(self, mod):
+        mock_model = MagicMock()
+        wrapper = mod._ModelWrapper(mock_model)
+        ids, mask, types = MagicMock(), MagicMock(), MagicMock()
+
+        result = wrapper.forward(ids, mask, types)
+
+        mock_model.assert_called_once_with(
+            input_ids=ids,
+            attention_mask=mask,
+            token_type_ids=types,
+        )
+        assert result is mock_model.return_value.last_hidden_state
+
+    def test_forward_returns_last_hidden_state(self, mod):
+        mock_model = MagicMock()
+        mock_model.return_value.last_hidden_state = "expected"
+        wrapper = mod._ModelWrapper(mock_model)
+
+        result = wrapper.forward(MagicMock(), MagicMock(), MagicMock())
+
+        assert result == "expected"
+
+
+# ---------------------------------------------------------------------------
+# main — idempotency
+# ---------------------------------------------------------------------------
+
+class TestMainIdempotent:
+    def test_exits_early_when_model_exists(self, mod, tmp_path, monkeypatch):
+        onnx = tmp_path / "model.onnx"
+        onnx.write_bytes(b"")
+        monkeypatch.setattr(mod, "ONNX_PATH", onnx)
+        with patch("sys.exit", side_effect=SystemExit(0)):
+            with pytest.raises(SystemExit):
+                mod.main()

--- a/pipeline/tests/test_03_embed_corpus.py
+++ b/pipeline/tests/test_03_embed_corpus.py
@@ -1,0 +1,164 @@
+"""Tests for pipeline/03_embed_corpus.py."""
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mod(pipeline_loader):
+    return pipeline_loader("03_embed_corpus.py")
+
+
+# ---------------------------------------------------------------------------
+# parse_release_year
+# ---------------------------------------------------------------------------
+
+class TestParseReleaseYear:
+    def test_valid_yyyy_mm_dd(self, mod):
+        assert mod.parse_release_year("2000-11-22") == 2000
+
+    def test_bare_year_returns_none(self, mod):
+        assert mod.parse_release_year("1979") is None
+
+    def test_empty_string_returns_none(self, mod):
+        assert mod.parse_release_year("") is None
+
+    def test_unknown_string_returns_none(self, mod):
+        assert mod.parse_release_year("unknown") is None
+
+    def test_yyyy_mm_returns_none(self, mod):
+        assert mod.parse_release_year("2005-03") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_genres
+# ---------------------------------------------------------------------------
+
+class TestExtractGenres:
+    def test_returns_genre_values(self, mod):
+        result = mod.extract_genres('{"k": "Drama", "k2": "Adventure"}')
+        assert sorted(result) == ["Adventure", "Drama"]
+
+    def test_empty_object_returns_empty_list(self, mod):
+        assert mod.extract_genres("{}") == []
+
+
+# ---------------------------------------------------------------------------
+# load_metadata
+# ---------------------------------------------------------------------------
+
+class TestLoadMetadata:
+    @pytest.fixture
+    def metadata_file(self, tmp_path):
+        # 9 tab-separated columns: id, _, title, release_date, _, _, _, _, genres
+        rows = [
+            "111\tx\tCast Away\t2000-11-22\tx\tx\tx\tx\t{}",
+            "222\tx\tAlien\t1979\tx\tx\tx\tx\t{}",
+            "333\tx\tUnknown\t\tx\tx\tx\tx\t{}",
+            "555\tx\tOrphan\t2001-05-01\tx\tx\tx\tx\t{}",
+        ]
+        p = tmp_path / "movie.metadata.tsv"
+        p.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        return p
+
+    def test_keyed_by_movie_id(self, mod, metadata_file):
+        result = mod.load_metadata(metadata_file)
+        assert "111" in result
+
+    def test_title_value(self, mod, metadata_file):
+        result = mod.load_metadata(metadata_file)
+        assert result["111"]["title"] == "Cast Away"
+
+    def test_row_count(self, mod, metadata_file):
+        result = mod.load_metadata(metadata_file)
+        assert len(result) == 4
+
+
+# ---------------------------------------------------------------------------
+# load_summaries
+# ---------------------------------------------------------------------------
+
+class TestLoadSummaries:
+    @pytest.fixture
+    def summaries_file(self, tmp_path):
+        rows = [
+            "111\tChuck Noland works for FedEx and crash-lands on an island.",
+            "222\tIn space, no one can hear you scream.",
+            "333\tA short summary.",
+        ]
+        p = tmp_path / "plot_summaries.txt"
+        p.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        return p
+
+    def test_keyed_by_movie_id(self, mod, summaries_file):
+        result = mod.load_summaries(summaries_file)
+        assert "111" in result
+
+    def test_summary_contains_expected_text(self, mod, summaries_file):
+        result = mod.load_summaries(summaries_file)
+        assert "FedEx" in result["111"]
+
+
+# ---------------------------------------------------------------------------
+# join_data
+# ---------------------------------------------------------------------------
+
+class TestJoinData:
+    @pytest.fixture
+    def metadata_map(self):
+        return {
+            "111": {"title": "Cast Away", "movie_release_date": "2000-11-22", "movie_genres": '{"k": "Drama"}'},
+            "222": {"title": "Alien", "movie_release_date": "1979", "movie_genres": "{}"},
+            "333": {"title": "No Summary Here", "movie_release_date": "2001-01-01", "movie_genres": "{}"},
+        }
+
+    @pytest.fixture
+    def summaries_map(self):
+        return {
+            "111": "Chuck Noland works for FedEx.",
+            "222": "In space, no one can hear you scream.",
+            "555": "Orphan entry with no metadata.",
+        }
+
+    def test_includes_matched_records(self, mod, metadata_map, summaries_map):
+        result = mod.join_data(metadata_map, summaries_map)
+        ids = [r["movie_id"] for r in result]
+        assert "111" in ids
+        assert "222" in ids
+
+    def test_excludes_record_without_summary(self, mod, metadata_map, summaries_map):
+        result = mod.join_data(metadata_map, summaries_map)
+        ids = [r["movie_id"] for r in result]
+        assert "333" not in ids
+
+    def test_excludes_summary_without_metadata(self, mod, metadata_map, summaries_map):
+        result = mod.join_data(metadata_map, summaries_map)
+        ids = [r["movie_id"] for r in result]
+        assert "555" not in ids
+
+    def test_record_has_required_fields(self, mod, metadata_map, summaries_map):
+        result = mod.join_data(metadata_map, summaries_map)
+        rec = next(r for r in result if r["movie_id"] == "111")
+        assert rec["title"] == "Cast Away"
+        assert isinstance(rec["genres"], list)
+        assert isinstance(rec["summary_snippet"], str)
+
+    def test_release_year_parsed_from_date(self, mod, metadata_map, summaries_map):
+        result = mod.join_data(metadata_map, summaries_map)
+        rec = next(r for r in result if r["movie_id"] == "111")
+        assert rec["release_year"] == 2000
+
+    def test_release_year_none_for_invalid_date(self, mod, metadata_map, summaries_map):
+        result = mod.join_data(metadata_map, summaries_map)
+        rec = next(r for r in result if r["movie_id"] == "222")
+        assert rec["release_year"] is None
+
+    def test_summary_snippet_capped_at_300_chars(self, mod, metadata_map):
+        long_summaries = {"111": "x" * 400, "222": "short"}
+        result = mod.join_data(metadata_map, long_summaries)
+        rec = next(r for r in result if r["movie_id"] == "111")
+        assert len(rec["summary_snippet"]) == 300
+
+    def test_short_summary_kept_as_is(self, mod, metadata_map, summaries_map):
+        result = mod.join_data(metadata_map, summaries_map)
+        rec = next(r for r in result if r["movie_id"] == "222")
+        assert rec["summary_snippet"] == "In space, no one can hear you scream."

--- a/pipeline/tests/test_04_ingest_qdrant.py
+++ b/pipeline/tests/test_04_ingest_qdrant.py
@@ -1,0 +1,79 @@
+"""Tests for pipeline/04_ingest_qdrant.py."""
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock
+
+
+@pytest.fixture(scope="module")
+def mod(pipeline_loader):
+    return pipeline_loader("04_ingest_qdrant.py")
+
+
+@pytest.fixture
+def sample_embeddings():
+    return np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype="float32")
+
+
+@pytest.fixture
+def sample_metadata():
+    return [
+        {"movie_id": "111", "title": "Cast Away", "release_year": 2000, "genres": ["Drama"]},
+        {"movie_id": "222", "title": "Alien", "release_year": None, "genres": []},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# build_points
+# ---------------------------------------------------------------------------
+
+class TestBuildPoints:
+    def test_returns_one_point_per_embedding(self, mod, sample_embeddings, sample_metadata):
+        points = mod.build_points(sample_embeddings, sample_metadata)
+        assert len(points) == 2
+
+    def test_ids_are_zero_based_integers(self, mod, sample_embeddings, sample_metadata):
+        points = mod.build_points(sample_embeddings, sample_metadata)
+        assert [p.id for p in points] == [0, 1]
+
+    def test_thumbnail_url_is_none(self, mod, sample_embeddings, sample_metadata):
+        points = mod.build_points(sample_embeddings, sample_metadata)
+        for p in points:
+            assert p.payload["thumbnail_url"] is None
+
+    def test_payload_contains_metadata_fields(self, mod, sample_embeddings, sample_metadata):
+        points = mod.build_points(sample_embeddings, sample_metadata)
+        p = points[0]
+        assert p.payload["movie_id"] == "111"
+        assert p.payload["title"] == "Cast Away"
+        assert p.payload["release_year"] == 2000
+        assert p.payload["genres"] == ["Drama"]
+
+    def test_vector_matches_embedding_row(self, mod, sample_embeddings, sample_metadata):
+        points = mod.build_points(sample_embeddings, sample_metadata)
+        np.testing.assert_allclose(points[0].vector, sample_embeddings[0].tolist())
+        np.testing.assert_allclose(points[1].vector, sample_embeddings[1].tolist())
+
+
+# ---------------------------------------------------------------------------
+# setup_collection
+# ---------------------------------------------------------------------------
+
+class TestCollectionSetup:
+    def test_collection_created_with_384_dims_cosine(self, mod):
+        mock_client = MagicMock()
+        mod.setup_collection(mock_client, "movies")
+
+        called = mock_client.recreate_collection.called or mock_client.create_collection.called
+        assert called, "Expected recreate_collection or create_collection to be called"
+
+        call_args = (
+            mock_client.recreate_collection.call_args
+            if mock_client.recreate_collection.called
+            else mock_client.create_collection.call_args
+        )
+
+        vectors_config = call_args.kwargs.get("vectors_config") or call_args.kwargs.get("vectors")
+        assert vectors_config is not None, "vectors_config not passed to collection call"
+        assert vectors_config.size == 384
+        assert vectors_config.distance == "Cosine"

--- a/pipeline/tests/test_integration.py
+++ b/pipeline/tests/test_integration.py
@@ -1,0 +1,341 @@
+"""Integration tests for the full offline pipeline (steps 1–5)."""
+
+import io
+import json
+import os
+import sys
+import tarfile
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mod_01(pipeline_loader): return pipeline_loader("01_download_corpus.py")
+
+@pytest.fixture(scope="module")
+def mod_02(pipeline_loader): return pipeline_loader("02_export_model.py")
+
+@pytest.fixture(scope="module")
+def mod_03(pipeline_loader): return pipeline_loader("03_embed_corpus.py")
+
+@pytest.fixture(scope="module")
+def mod_04(pipeline_loader): return pipeline_loader("04_ingest_qdrant.py")
+
+@pytest.fixture(scope="module")
+def mod_05(pipeline_loader): return pipeline_loader("05_enrich_tmdb.py")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tar_gz(files: dict) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name=f"MovieSummaries/{name}")
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _mock_urlopen(tar_bytes: bytes) -> MagicMock:
+    resp = MagicMock()
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    resp.read.side_effect = [tar_bytes, b""]
+    resp.headers.get.return_value = str(len(tar_bytes))
+    return resp
+
+
+def _fake_tokenize(*args, **kwargs):
+    texts = args[0] if args else ""
+    B = len(texts) if isinstance(texts, list) else 1
+    return {
+        "input_ids": np.zeros((B, 128), dtype="int32"),
+        "attention_mask": np.ones((B, 128), dtype="int32"),
+    }
+
+
+def _fake_infer_batch(grpcclient, client, input_ids, attention_mask, token_type_ids):
+    B = input_ids.shape[0]
+    return np.ones((B, 384), dtype="float32")
+
+
+# ---------------------------------------------------------------------------
+# Step 1: download_corpus
+# ---------------------------------------------------------------------------
+
+class TestStep1DownloadCorpus:
+    def test_extracts_both_corpus_files(self, mod_01, tmp_path):
+        tar_bytes = _make_tar_gz({
+            "movie.metadata.tsv": b"111\tx\tCast Away\t2000-01-01\tx\tx\tx\tx\t{}\n",
+            "plot_summaries.txt": b"111\tA survival story.\n",
+        })
+        with patch.object(mod_01.urllib.request, "urlopen", return_value=_mock_urlopen(tar_bytes)):
+            mod_01.download_and_extract("http://fake", tmp_path)
+
+        assert (tmp_path / "movie.metadata.tsv").exists()
+        assert (tmp_path / "plot_summaries.txt").exists()
+        assert (tmp_path / "movie.metadata.tsv").read_bytes() == b"111\tx\tCast Away\t2000-01-01\tx\tx\tx\tx\t{}\n"
+
+    def test_idempotent_skips_when_already_downloaded(self, mod_01, tmp_path, monkeypatch):
+        (tmp_path / "movie.metadata.tsv").write_text("data")
+        (tmp_path / "plot_summaries.txt").write_text("data")
+        monkeypatch.setattr(mod_01, "METADATA_PATH", tmp_path / "movie.metadata.tsv")
+        monkeypatch.setattr(mod_01, "SUMMARIES_PATH", tmp_path / "plot_summaries.txt")
+
+        with patch.object(mod_01, "download_and_extract") as mock_dl, \
+             patch("sys.exit", side_effect=SystemExit(0)):
+            with pytest.raises(SystemExit):
+                mod_01.main()
+        mock_dl.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Step 2: export_model (idempotency only)
+# ---------------------------------------------------------------------------
+
+class TestStep2ExportModel:
+    def test_skips_export_when_onnx_exists(self, mod_02, tmp_path, monkeypatch):
+        onnx_path = tmp_path / "model.onnx"
+        onnx_path.write_bytes(b"fake")
+        monkeypatch.setattr(mod_02, "ONNX_PATH", onnx_path)
+
+        with patch("sys.exit", side_effect=SystemExit(0)):
+            with pytest.raises(SystemExit) as exc_info:
+                mod_02.main()
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Step 3: embed_corpus
+# ---------------------------------------------------------------------------
+
+_METADATA_TSV = (
+    "111\tx\tCast Away\t2000-01-01\tx\tx\tx\tx\t{}\n"
+    "222\tx\tAlien\t1979-05-25\tx\tx\tx\tx\t{\"1\": \"Sci-Fi\"}\n"
+)
+_SUMMARIES_TXT = (
+    "111\tA survival story.\n"
+    "222\tA deadly alien creature.\n"
+)
+
+
+class TestStep3EmbedCorpus:
+    def test_writes_embeddings_npy_and_metadata_json(self, mod_03, tmp_path, monkeypatch):
+        meta_path = tmp_path / "movie.metadata.tsv"
+        summ_path = tmp_path / "plot_summaries.txt"
+        meta_path.write_text(_METADATA_TSV)
+        summ_path.write_text(_SUMMARIES_TXT)
+
+        emb_dir = tmp_path / "embeddings"
+        emb_path = emb_dir / "embeddings.npy"
+        meta_out = emb_dir / "metadata.json"
+
+        monkeypatch.setattr(mod_03, "METADATA_PATH", meta_path)
+        monkeypatch.setattr(mod_03, "SUMMARIES_PATH", summ_path)
+        monkeypatch.setattr(mod_03, "EMBEDDINGS_DIR", emb_dir)
+        monkeypatch.setattr(mod_03, "EMBEDDINGS_PATH", emb_path)
+        monkeypatch.setattr(mod_03, "METADATA_OUT_PATH", meta_out)
+        monkeypatch.setattr(mod_03, "_infer_batch", _fake_infer_batch)
+        monkeypatch.setattr(sys, "argv", ["03_embed_corpus.py"])
+
+        fake_tokenizer = MagicMock(side_effect=_fake_tokenize)
+        mock_auto_tokenizer = MagicMock()
+        mock_auto_tokenizer.from_pretrained.return_value = fake_tokenizer
+        monkeypatch.setattr(sys.modules["transformers"], "AutoTokenizer", mock_auto_tokenizer)
+
+        mod_03.main()
+
+        assert emb_path.exists()
+        assert meta_out.exists()
+        embeddings = np.load(str(emb_path))
+        assert embeddings.shape == (2, 384)
+        records = json.loads(meta_out.read_text())
+        assert len(records) == 2
+        assert all("title" in r and "movie_id" in r for r in records)
+
+    def test_idempotent_skips_when_outputs_exist(self, mod_03, tmp_path, monkeypatch):
+        emb_path = tmp_path / "embeddings.npy"
+        meta_out = tmp_path / "metadata.json"
+        np.save(str(emb_path), np.zeros((1, 384), dtype="float32"))
+        meta_out.write_text("[]")
+
+        monkeypatch.setattr(mod_03, "EMBEDDINGS_PATH", emb_path)
+        monkeypatch.setattr(mod_03, "METADATA_OUT_PATH", meta_out)
+        monkeypatch.setattr(sys, "argv", ["03_embed_corpus.py"])
+
+        with patch("sys.exit", side_effect=SystemExit(0)):
+            with pytest.raises(SystemExit) as exc_info:
+                mod_03.main()
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Step 4: ingest_qdrant
+# ---------------------------------------------------------------------------
+
+def _write_ingest_fixtures(tmp_path):
+    embeddings = np.array([[0.1] * 384, [0.2] * 384], dtype="float32")
+    metadata = [
+        {"movie_id": "111", "title": "Cast Away", "release_year": 2000, "genres": []},
+        {"movie_id": "222", "title": "Alien", "release_year": 1979, "genres": []},
+    ]
+    data_dir = tmp_path / "data" / "embeddings"
+    data_dir.mkdir(parents=True)
+    np.save(str(data_dir / "embeddings.npy"), embeddings)
+    (data_dir / "metadata.json").write_text(json.dumps(metadata))
+    return embeddings, metadata
+
+
+def _mock_qdrant(monkeypatch, mock_client):
+    """Replace QdrantClient in the stub module with a callable returning mock_client."""
+    mock_cls = MagicMock(return_value=mock_client)
+    monkeypatch.setattr(sys.modules["qdrant_client"], "QdrantClient", mock_cls)
+
+
+class TestStep4IngestQdrant:
+    def test_setup_collection_then_upsert(self, mod_04, tmp_path, monkeypatch):
+        _write_ingest_fixtures(tmp_path)
+        mock_client = MagicMock()
+        _mock_qdrant(monkeypatch, mock_client)
+
+        monkeypatch.setattr(sys, "argv", ["04_ingest_qdrant.py"])
+        monkeypatch.chdir(tmp_path)
+
+        mod_04.main()
+
+        assert mock_client.recreate_collection.called
+        assert mock_client.upsert.called
+        call_names = [str(c) for c in mock_client.method_calls]
+        setup_idx = next(i for i, n in enumerate(call_names) if "recreate_collection" in n)
+        upsert_idx = next(i for i, n in enumerate(call_names) if "upsert" in n)
+        assert setup_idx < upsert_idx
+
+    def test_upsert_receives_all_points(self, mod_04, tmp_path, monkeypatch):
+        _write_ingest_fixtures(tmp_path)
+        mock_client = MagicMock()
+        _mock_qdrant(monkeypatch, mock_client)
+
+        monkeypatch.setattr(sys, "argv", ["04_ingest_qdrant.py"])
+        monkeypatch.chdir(tmp_path)
+
+        mod_04.main()
+
+        all_points = []
+        for call in mock_client.upsert.call_args_list:
+            pts = call.kwargs.get("points") or (call.args[1] if len(call.args) > 1 else [])
+            all_points.extend(pts)
+        assert len(all_points) == 2
+
+    def test_idempotent_reruns_without_error(self, mod_04, tmp_path, monkeypatch):
+        _write_ingest_fixtures(tmp_path)
+        _mock_qdrant(monkeypatch, MagicMock())
+
+        monkeypatch.setattr(sys, "argv", ["04_ingest_qdrant.py"])
+        monkeypatch.chdir(tmp_path)
+
+        mod_04.main()
+        mod_04.main()
+
+
+# ---------------------------------------------------------------------------
+# Step 5: enrich_tmdb
+# ---------------------------------------------------------------------------
+
+def _patch_qdrant_models():
+    qdrant_models = sys.modules.get("qdrant_client.models")
+    if qdrant_models is not None:
+        qdrant_models.Filter = MagicMock
+        qdrant_models.FieldCondition = MagicMock
+        qdrant_models.MatchValue = MagicMock
+
+
+class TestStep5EnrichTmdb:
+    def test_sets_payload_only_for_points_with_poster(self, mod_05, monkeypatch):
+        _patch_qdrant_models()
+
+        point_with_poster = MagicMock()
+        point_with_poster.id = 1
+        point_with_poster.payload = {"title": "Cast Away", "release_year": 2000}
+
+        point_no_poster = MagicMock()
+        point_no_poster.id = 2
+        point_no_poster.payload = {"title": "Unknown", "release_year": None}
+
+        mock_client = MagicMock()
+        mock_client.scroll.side_effect = [
+            ([point_with_poster, point_no_poster], None),
+            ([], None),
+        ]
+        _mock_qdrant(monkeypatch, mock_client)
+
+        def _fake_get(url, params=None, **kwargs):
+            resp = MagicMock()
+            if (params or {}).get("query") == "Cast Away":
+                resp.json.return_value = {"results": [{"poster_path": "/abc.jpg"}]}
+            else:
+                resp.json.return_value = {"results": []}
+            return resp
+
+        mock_session = MagicMock()
+        mock_session.get.side_effect = _fake_get
+
+        monkeypatch.setenv("TMDB_API_KEY", "fake_key")
+        monkeypatch.setattr(sys, "argv", ["05_enrich_tmdb.py"])
+
+        with patch("requests.Session", return_value=mock_session), \
+             patch("time.sleep"):
+            mod_05.main()
+
+        assert mock_client.set_payload.call_count == 1
+        call_kw = mock_client.set_payload.call_args.kwargs
+        assert call_kw["payload"]["thumbnail_url"] == "/abc.jpg"
+        assert call_kw["points"] == [1]
+
+    def test_does_not_set_payload_when_no_poster(self, mod_05, monkeypatch):
+        _patch_qdrant_models()
+
+        point = MagicMock()
+        point.id = 3
+        point.payload = {"title": "No Poster Film", "release_year": None}
+
+        mock_client = MagicMock()
+        mock_client.scroll.side_effect = [([point], None), ([], None)]
+        _mock_qdrant(monkeypatch, mock_client)
+
+        mock_session = MagicMock()
+        mock_session.get.return_value.json.return_value = {"results": []}
+
+        monkeypatch.setenv("TMDB_API_KEY", "fake_key")
+        monkeypatch.setattr(sys, "argv", ["05_enrich_tmdb.py"])
+
+        with patch("requests.Session", return_value=mock_session), \
+             patch("time.sleep"):
+            mod_05.main()
+
+        mock_client.set_payload.assert_not_called()
+
+    def test_idempotent_no_error_on_rerun(self, mod_05, monkeypatch):
+        _patch_qdrant_models()
+
+        mock_client_1 = MagicMock()
+        mock_client_1.scroll.return_value = ([], None)
+        mock_client_2 = MagicMock()
+        mock_client_2.scroll.return_value = ([], None)
+        mock_cls = MagicMock(side_effect=[mock_client_1, mock_client_2])
+        monkeypatch.setattr(sys.modules["qdrant_client"], "QdrantClient", mock_cls)
+
+        mock_session = MagicMock()
+        mock_session.get.return_value.json.return_value = {"results": []}
+
+        monkeypatch.setenv("TMDB_API_KEY", "fake_key")
+        monkeypatch.setattr(sys, "argv", ["05_enrich_tmdb.py"])
+
+        with patch("requests.Session", return_value=mock_session), \
+             patch("time.sleep"):
+            mod_05.main()
+            mod_05.main()


### PR DESCRIPTION
## Summary
Adds `pipeline/tests/test_integration.py` with 11 integration tests covering the full offline pipeline flow across all five scripts.

## Changes
- `pipeline/tests/test_integration.py` — new file with integration tests for all five pipeline steps
- `pipeline/01_download_corpus.py` — previously untracked, now committed
- `pipeline/tests/conftest.py` — previously untracked, now committed
- `pipeline/tests/test_01_download_corpus.py` through `test_04_ingest_qdrant.py` — previously untracked, now committed

## Verification
All acceptance criteria from #10 verified before opening this PR.

- Integration tests cover the full pipeline flow for all five scripts ✓
- All 55 tests pass (11 new integration + 44 existing unit tests) ✓

Closes #10