### PR TITLE
Add .claude/settings.json with permission allowlist for remote agent

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(cd *)",
+      "Bash(for *)",
+      "Bash(state=*)",
+      "Bash(bash *)",
+      "Bash(python3 *)",
+      "Bash(python *)",
+      "Bash(pip3 install *)",
+      "Bash(pip install *)",
+      "Bash(grep *)",
+      "Bash(xargs *)",
+      "Bash(wait)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pipeline/*.egg-info
 .env
 *.DS_Store
 prompt.txt
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` (committed) with a broad bash allowlist so the `daily-task-runner` CCR agent can run without permission prompts when no user is present
- Gitignores `.claude/settings.local.json` (personal local overrides)

## Test plan
- [ ] Verify remote agent fires at 3 PM EST without stalling on permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)