### PR TITLE
Implement TritonGrpcConfig with ManagedChannel and stub beans

### DIFF
--- a/api/src/main/java/com/moviesearch/config/TritonGrpcConfig.java
+++ b/api/src/main/java/com/moviesearch/config/TritonGrpcConfig.java
@@ -1,0 +1,40 @@
+package com.moviesearch.config;
+
+import inference.GRPCInferenceServiceGrpc;
+import inference.GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingStub;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import jakarta.annotation.PreDestroy;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class TritonGrpcConfig {
+
+    private ManagedChannel channel;
+
+    @Bean
+    @ConditionalOnProperty(name = "triton.mock", havingValue = "false", matchIfMissing = true)
+    public ManagedChannel tritonChannel(TritonProperties props) {
+        channel = ManagedChannelBuilder.forAddress(props.getHost(), props.getPort())
+                .usePlaintext()
+                .build();
+        return channel;
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "triton.mock", havingValue = "false", matchIfMissing = true)
+    public GRPCInferenceServiceBlockingStub tritonStub(ManagedChannel channel) {
+        return GRPCInferenceServiceGrpc.newBlockingStub(channel);
+    }
+
+    @PreDestroy
+    public void shutdown() throws InterruptedException {
+        if (channel != null) {
+            channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/api/src/test/java/com/moviesearch/config/TritonGrpcConfigTest.java
+++ b/api/src/test/java/com/moviesearch/config/TritonGrpcConfigTest.java
@@ -1,0 +1,60 @@
+package com.moviesearch.config;
+
+import inference.GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingStub;
+import io.grpc.ManagedChannel;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class TritonGrpcConfigTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(TritonGrpcConfig.class, TritonProperties.class);
+
+    @Test
+    void bothBeansRegisteredWhenMockAbsent() {
+        contextRunner.run(ctx -> {
+            assertThat(ctx).hasSingleBean(ManagedChannel.class);
+            assertThat(ctx).hasSingleBean(GRPCInferenceServiceBlockingStub.class);
+        });
+    }
+
+    @Test
+    void bothBeansRegisteredWhenMockFalse() {
+        contextRunner
+                .withPropertyValues("triton.mock=false")
+                .run(ctx -> {
+                    assertThat(ctx).hasSingleBean(ManagedChannel.class);
+                    assertThat(ctx).hasSingleBean(GRPCInferenceServiceBlockingStub.class);
+                });
+    }
+
+    @Test
+    void noBeansRegisteredWhenMockTrue() {
+        contextRunner
+                .withPropertyValues("triton.mock=true")
+                .run(ctx -> {
+                    assertThat(ctx).doesNotHaveBean(ManagedChannel.class);
+                    assertThat(ctx).doesNotHaveBean(GRPCInferenceServiceBlockingStub.class);
+                });
+    }
+
+    @Test
+    void preDestroyShutsDownChannel() throws Exception {
+        ManagedChannel mockChannel = mock(ManagedChannel.class);
+        when(mockChannel.shutdown()).thenReturn(mockChannel);
+        when(mockChannel.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS)).thenReturn(true);
+
+        TritonGrpcConfig config = new TritonGrpcConfig();
+        var field = TritonGrpcConfig.class.getDeclaredField("channel");
+        field.setAccessible(true);
+        field.set(config, mockChannel);
+
+        config.shutdown();
+
+        verify(mockChannel).shutdown();
+        verify(mockChannel).awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
## Summary
Adds `TritonGrpcConfig`, a Spring `@Configuration` class that conditionally produces a `ManagedChannel` and `GRPCInferenceServiceBlockingStub` bean based on the `triton.mock` property, with graceful channel shutdown via `@PreDestroy`.

## Changes
- `api/src/main/java/com/moviesearch/config/TritonGrpcConfig.java` — new configuration class with conditional beans and `@PreDestroy` shutdown
- `api/src/test/java/com/moviesearch/config/TritonGrpcConfigTest.java` — unit tests using `ApplicationContextRunner` to verify all three conditional scenarios and the `@PreDestroy` shutdown behavior

## Verification
All acceptance criteria from #33 verified before opening this PR.

Closes #33