### PR TITLE
Implement EmbeddingServiceImpl with Triton gRPC and update wiring

### DIFF
--- a/api/src/main/java/com/moviesearch/exception/EmbeddingServiceException.java
+++ b/api/src/main/java/com/moviesearch/exception/EmbeddingServiceException.java
@@ -7,6 +7,10 @@ public class EmbeddingServiceException extends RuntimeException {
     public static final String INVALID_REQUEST =
         "Embedding service rejected request: invalid input";
 
+    public static String invalidVectorDimension(int actual) {
+        return "Embedding service returned unexpected vector dimension: " + actual;
+    }
+
     public EmbeddingServiceException(String reason) {
         super(reason);
     }

--- a/api/src/main/java/com/moviesearch/service/impl/EmbeddingServiceImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/EmbeddingServiceImpl.java
@@ -1,0 +1,90 @@
+package com.moviesearch.service.impl;
+
+import com.google.protobuf.ByteString;
+import com.moviesearch.config.TritonProperties;
+import com.moviesearch.exception.EmbeddingServiceException;
+import com.moviesearch.model.EmbeddingRequest;
+import com.moviesearch.model.EmbeddingResponse;
+import com.moviesearch.service.EmbeddingService;
+import inference.GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingStub;
+import inference.Inference.InferTensorContents;
+import inference.Inference.ModelInferRequest;
+import inference.Inference.ModelInferResponse;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@ConditionalOnProperty(name = "triton.mock", havingValue = "false", matchIfMissing = true)
+public class EmbeddingServiceImpl implements EmbeddingService {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbeddingServiceImpl.class);
+    private static final int VECTOR_DIM = 384;
+
+    private final GRPCInferenceServiceBlockingStub stub;
+    private final TritonProperties props;
+
+    public EmbeddingServiceImpl(GRPCInferenceServiceBlockingStub stub, TritonProperties props) {
+        this.stub = stub;
+        this.props = props;
+    }
+
+    @Override
+    public EmbeddingResponse embed(EmbeddingRequest request) {
+        String text = request.getText();
+        String textPreview = text.length() > 50 ? text.substring(0, 50) : text;
+        log.debug("EmbeddingService.embed called [text='{}']", textPreview);
+
+        ModelInferRequest grpcRequest = ModelInferRequest.newBuilder()
+            .setModelName(props.getModelName())
+            .addInputs(ModelInferRequest.InferInputTensor.newBuilder()
+                .setName("TEXT")
+                .setDatatype("BYTES")
+                .addShape(1).addShape(1)
+                .setContents(InferTensorContents.newBuilder()
+                    .addBytesContents(ByteString.copyFromUtf8(text))))
+            .addOutputs(ModelInferRequest.InferRequestedOutputTensor.newBuilder()
+                .setName("sentence_embedding"))
+            .build();
+
+        ModelInferResponse response;
+        try {
+            response = stub
+                .withDeadlineAfter(props.getDeadlineMs(), TimeUnit.MILLISECONDS)
+                .modelInfer(grpcRequest);
+        } catch (StatusRuntimeException e) {
+            throw mapException(e);
+        }
+
+        List<Float> floats = response.getOutputs(0).getContents().getFp32ContentsList();
+        if (floats.size() != VECTOR_DIM) {
+            throw new EmbeddingServiceException(EmbeddingServiceException.invalidVectorDimension(floats.size()));
+        }
+
+        float[] vector = new float[VECTOR_DIM];
+        for (int i = 0; i < VECTOR_DIM; i++) {
+            vector[i] = floats.get(i);
+        }
+
+        log.debug("EmbeddingService.embed returning vector [dimensions={}]", vector.length);
+        return new EmbeddingResponse(vector);
+    }
+
+    private EmbeddingServiceException mapException(StatusRuntimeException e) {
+        Status.Code code = e.getStatus().getCode();
+        return switch (code) {
+            case UNAVAILABLE, DEADLINE_EXCEEDED -> new EmbeddingServiceException(
+                EmbeddingServiceException.CONNECTION_REFUSED, e);
+            case INVALID_ARGUMENT -> new EmbeddingServiceException(
+                EmbeddingServiceException.INVALID_REQUEST, e);
+            default -> new EmbeddingServiceException(
+                EmbeddingServiceException.CONNECTION_REFUSED, e);
+        };
+    }
+}

--- a/api/src/main/java/com/moviesearch/service/impl/MockEmbeddingService.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockEmbeddingService.java
@@ -5,9 +5,13 @@ import com.moviesearch.model.EmbeddingResponse;
 import com.moviesearch.service.EmbeddingService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 @Service
+@Primary
+@ConditionalOnProperty(name = "triton.mock", havingValue = "true")
 public class MockEmbeddingService implements EmbeddingService {
 
     private static final Logger log = LoggerFactory.getLogger(MockEmbeddingService.class);

--- a/api/src/test/java/com/moviesearch/controller/SearchControllerTest.java
+++ b/api/src/test/java/com/moviesearch/controller/SearchControllerTest.java
@@ -148,6 +148,17 @@ class SearchControllerTest {
     }
 
     @Test
+    void search_embeddingServiceInvalidRequest() throws Exception {
+        when(searchService.search(argThat(r -> "foo".equals(r.getQuery()))))
+            .thenThrow(new EmbeddingServiceException(EmbeddingServiceException.INVALID_REQUEST));
+
+        mockMvc.perform(get("/api/search").param("q", "foo"))
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(jsonPath("$.detail").value(
+                "Embedding service rejected request: invalid input"));
+    }
+
+    @Test
     void search_vectorSearchConnectionRefused() throws Exception {
         when(searchService.search(argThat(r -> "foo".equals(r.getQuery()))))
             .thenThrow(new VectorSearchServiceException(VectorSearchServiceException.CONNECTION_REFUSED));

--- a/api/src/test/java/com/moviesearch/service/impl/EmbeddingServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/EmbeddingServiceImplTest.java
@@ -1,0 +1,206 @@
+package com.moviesearch.service.impl;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.moviesearch.config.TritonProperties;
+import com.moviesearch.exception.EmbeddingServiceException;
+import com.moviesearch.model.EmbeddingRequest;
+import com.moviesearch.model.EmbeddingResponse;
+import inference.GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingStub;
+import inference.Inference.InferTensorContents;
+import inference.Inference.ModelInferRequest;
+import inference.Inference.ModelInferResponse;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmbeddingServiceImplTest {
+
+    @Mock
+    private GRPCInferenceServiceBlockingStub stub;
+
+    private TritonProperties props;
+    private EmbeddingServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        props = new TritonProperties();
+        service = new EmbeddingServiceImpl(stub, props);
+    }
+
+    private ModelInferResponse buildResponse(int dims) {
+        InferTensorContents.Builder contents = InferTensorContents.newBuilder();
+        for (int i = 0; i < dims; i++) {
+            contents.addFp32Contents(0.1f * i);
+        }
+        ModelInferResponse.InferOutputTensor output = ModelInferResponse.InferOutputTensor.newBuilder()
+            .setName("sentence_embedding")
+            .setDatatype("FP32")
+            .addShape(1).addShape(dims)
+            .setContents(contents)
+            .build();
+        return ModelInferResponse.newBuilder().addOutputs(output).build();
+    }
+
+    private ListAppender<ILoggingEvent> attachLogAppender(Class<?> clazz) {
+        Logger logger = (Logger) LoggerFactory.getLogger(clazz);
+        logger.setLevel(Level.DEBUG);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        return appender;
+    }
+
+    // --- Happy paths ---
+
+    @Test
+    void embed_returnsCorrectDimensions() {
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
+
+        EmbeddingResponse response = service.embed(new EmbeddingRequest("hello world"));
+
+        assertThat(response.getVector()).hasSize(384);
+    }
+
+    @Test
+    void embed_vectorValuesMatchResponse() {
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
+
+        float[] vector = service.embed(new EmbeddingRequest("hello world")).getVector();
+
+        assertThat(vector[0]).isEqualTo(0.0f);
+        assertThat(vector[1]).isEqualTo(0.1f);
+        assertThat(vector[2]).isEqualTo(0.2f);
+    }
+
+    @Test
+    void embed_logEntryMessage() {
+        ListAppender<ILoggingEvent> appender = attachLogAppender(EmbeddingServiceImpl.class);
+        Logger logger = (Logger) LoggerFactory.getLogger(EmbeddingServiceImpl.class);
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
+
+        try {
+            service.embed(new EmbeddingRequest("hello world"));
+            List<String> messages = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage).toList();
+            assertThat(messages).contains("EmbeddingService.embed called [text='hello world']");
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    void embed_logExitMessage() {
+        ListAppender<ILoggingEvent> appender = attachLogAppender(EmbeddingServiceImpl.class);
+        Logger logger = (Logger) LoggerFactory.getLogger(EmbeddingServiceImpl.class);
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
+
+        try {
+            service.embed(new EmbeddingRequest("hello world"));
+            List<String> messages = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage).toList();
+            assertThat(messages).contains("EmbeddingService.embed returning vector [dimensions=384]");
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    @Test
+    void embed_longTextTruncatedInLog() {
+        ListAppender<ILoggingEvent> appender = attachLogAppender(EmbeddingServiceImpl.class);
+        Logger logger = (Logger) LoggerFactory.getLogger(EmbeddingServiceImpl.class);
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
+
+        String longText = "a".repeat(100);
+        try {
+            service.embed(new EmbeddingRequest(longText));
+            List<String> messages = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage).toList();
+            String expected = "EmbeddingService.embed called [text='" + "a".repeat(50) + "']";
+            assertThat(messages).contains(expected);
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    // --- gRPC status mapping ---
+
+    @Test
+    void embed_grpcUnavailable_throwsConnectionRefused() {
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class)))
+            .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE));
+
+        assertThatThrownBy(() -> service.embed(new EmbeddingRequest("hello")))
+            .isInstanceOf(EmbeddingServiceException.class)
+            .hasMessage(EmbeddingServiceException.CONNECTION_REFUSED);
+    }
+
+    @Test
+    void embed_grpcDeadlineExceeded_throwsConnectionRefused() {
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class)))
+            .thenThrow(new StatusRuntimeException(Status.DEADLINE_EXCEEDED));
+
+        assertThatThrownBy(() -> service.embed(new EmbeddingRequest("hello")))
+            .isInstanceOf(EmbeddingServiceException.class)
+            .hasMessage(EmbeddingServiceException.CONNECTION_REFUSED);
+    }
+
+    @Test
+    void embed_grpcInvalidArgument_throwsInvalidRequest() {
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class)))
+            .thenThrow(new StatusRuntimeException(Status.INVALID_ARGUMENT));
+
+        assertThatThrownBy(() -> service.embed(new EmbeddingRequest("hello")))
+            .isInstanceOf(EmbeddingServiceException.class)
+            .hasMessage(EmbeddingServiceException.INVALID_REQUEST);
+    }
+
+    @Test
+    void embed_grpcUnknownStatus_throwsConnectionRefused() {
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class)))
+            .thenThrow(new StatusRuntimeException(Status.INTERNAL));
+
+        assertThatThrownBy(() -> service.embed(new EmbeddingRequest("hello")))
+            .isInstanceOf(EmbeddingServiceException.class)
+            .hasMessage(EmbeddingServiceException.CONNECTION_REFUSED);
+    }
+
+    // --- Invalid vector dimension ---
+
+    @Test
+    void embed_wrongDimension_throwsException() {
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(100));
+
+        assertThatThrownBy(() -> service.embed(new EmbeddingRequest("hello")))
+            .isInstanceOf(EmbeddingServiceException.class)
+            .hasMessage(EmbeddingServiceException.invalidVectorDimension(100));
+    }
+}


### PR DESCRIPTION
## Summary
Adds real gRPC-based embedding via Triton, restricts MockEmbeddingService to `triton.mock=true`, and adds controller-layer tests for 503 error paths.

## Changes
- `api/src/main/java/com/moviesearch/config/TritonGrpcConfig.java` — new: provides `ManagedChannel` and `GRPCInferenceServiceBlockingStub` beans (conditional on `triton.mock` not being true)
- `api/src/main/java/com/moviesearch/service/impl/EmbeddingServiceImpl.java` — new: production gRPC implementation of `EmbeddingService`
- `api/src/main/java/com/moviesearch/service/impl/MockEmbeddingService.java` — added `@ConditionalOnProperty(name="triton.mock", havingValue="true")` and `@Primary`
- `api/src/main/java/com/moviesearch/exception/EmbeddingServiceException.java` — added `invalidVectorDimension(int actual)` static factory method
- `api/src/test/java/com/moviesearch/service/impl/EmbeddingServiceImplTest.java` — new: 9 unit tests covering happy path, logging, gRPC error mapping, and dimension validation
- `api/src/test/java/com/moviesearch/controller/SearchControllerTest.java` — added 503 assertion for `INVALID_REQUEST` error path

## Verification
All acceptance criteria from #34 verified before opening this PR.

Closes #34