### PR TITLE
Add QdrantProperties config class and make MockVectorSearchService conditional

### DIFF
--- a/api/src/main/java/com/moviesearch/MovieSearchApplication.java
+++ b/api/src/main/java/com/moviesearch/MovieSearchApplication.java
@@ -3,13 +3,14 @@ package com.moviesearch;
 import com.moviesearch.config.DatasetProperties;
 import com.moviesearch.config.ModelProperties;
 import com.moviesearch.config.ProjectProperties;
+import com.moviesearch.config.QdrantProperties;
 import com.moviesearch.config.TritonProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties({DatasetProperties.class, ModelProperties.class, TritonProperties.class, ProjectProperties.class})
+@EnableConfigurationProperties({DatasetProperties.class, ModelProperties.class, TritonProperties.class, ProjectProperties.class, QdrantProperties.class})
 public class MovieSearchApplication {
 
     public static void main(String[] args) {

--- a/api/src/main/java/com/moviesearch/config/QdrantProperties.java
+++ b/api/src/main/java/com/moviesearch/config/QdrantProperties.java
@@ -1,0 +1,15 @@
+package com.moviesearch.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "qdrant")
+public class QdrantProperties {
+
+    private String baseUrl = "http://localhost:6333";
+    private boolean mock = false;
+
+    public String getBaseUrl() { return baseUrl; }
+    public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
+    public boolean isMock() { return mock; }
+    public void setMock(boolean mock) { this.mock = mock; }
+}

--- a/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
@@ -6,11 +6,13 @@ import com.moviesearch.model.VectorSearchResponse;
 import com.moviesearch.service.VectorSearchService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@ConditionalOnProperty(name = "qdrant.mock", havingValue = "true", matchIfMissing = true)
 public class MockVectorSearchService implements VectorSearchService {
 
     private static final Logger log = LoggerFactory.getLogger(MockVectorSearchService.class);

--- a/api/src/test/java/com/moviesearch/config/QdrantPropertiesTest.java
+++ b/api/src/test/java/com/moviesearch/config/QdrantPropertiesTest.java
@@ -1,0 +1,24 @@
+package com.moviesearch.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class QdrantPropertiesTest {
+
+    @Autowired
+    private QdrantProperties qdrantProperties;
+
+    @Test
+    void defaultBaseUrlIsLocalhost6333() {
+        assertThat(qdrantProperties.getBaseUrl()).isEqualTo("http://localhost:6333");
+    }
+
+    @Test
+    void defaultMockIsFalse() {
+        assertThat(qdrantProperties.isMock()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
Adds a `QdrantProperties` configuration class bound to the `qdrant` prefix and makes `MockVectorSearchService` conditionally load only when `qdrant.mock=true` (or property is absent, via `matchIfMissing=true`).

## Changes
- `api/src/main/java/com/moviesearch/config/QdrantProperties.java` — new class with `baseUrl` (default `http://localhost:6333`) and `mock` (default `false`) fields
- `api/src/main/java/com/moviesearch/MovieSearchApplication.java` — registered `QdrantProperties.class` in `@EnableConfigurationProperties`
- `api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java` — added `@ConditionalOnProperty(name = \"qdrant.mock\", havingValue = \"true\", matchIfMissing = true)`
- `api/src/test/java/com/moviesearch/config/QdrantPropertiesTest.java` — new unit tests verifying default `baseUrl` and `mock` values

## Verification
All acceptance criteria from #40 verified before opening this PR.

Closes #40