### PR TITLE
Create Makefile and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your values before running `make pipeline`
+
+# TMDB v3 API key — required by pipeline/05_enrich_tmdb.py for poster URL enrichment
+TMDB_API_KEY=your_tmdb_api_key_here
+
+# Absolute path to the repo root — used by pipeline scripts referencing data/ and model-repository/ directories
+PROJECT_ROOT=/path/to/movie-semantic-search

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: up down pipeline clean
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+pipeline:
+	cd pipeline && pip install -r requirements.txt && \
+	python 01_download_corpus.py && \
+	python 02_export_model.py && \
+	python 03_embed_corpus.py && \
+	python 04_ingest_qdrant.py && \
+	python 05_enrich_tmdb.py
+
+clean:
+	rm -rf data/raw/ data/embeddings/ \
+	  model-repository/all-minilm-l6-v2/1/model.onnx \
+	  model-repository/all-minilm-l6-v2/1/tokenizer.json \
+	  model-repository/all-minilm-l6-v2/1/tokenizer_config.json \
+	  model-repository/all-minilm-l6-v2/1/vocab.txt \
+	  model-repository/all-minilm-l6-v2/1/special_tokens_map.json
+	docker compose down -v


### PR DESCRIPTION
## Summary
Adds a root-level Makefile with four targets (up, down, pipeline, clean) and a .env.example documenting required environment variables.

## Changes
- `Makefile` — created with `up`, `down`, `pipeline`, and `clean` targets matching the README quick-start
- `.env.example` — created documenting `TMDB_API_KEY` and `PROJECT_ROOT` variables

## Verification
All acceptance criteria from #57 verified before opening this PR.

Closes #57