### PR TITLE
Implement DockerComposeRunner interface and DockerComposeRunnerImpl

### DIFF
--- a/api/src/main/java/com/moviesearch/service/DockerComposeRunner.java
+++ b/api/src/main/java/com/moviesearch/service/DockerComposeRunner.java
@@ -1,0 +1,7 @@
+package com.moviesearch.service;
+
+import java.io.IOException;
+
+public interface DockerComposeRunner {
+    void run(String... args) throws IOException, InterruptedException;
+}

--- a/api/src/main/java/com/moviesearch/service/impl/DockerComposeRunnerImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/DockerComposeRunnerImpl.java
@@ -1,0 +1,45 @@
+package com.moviesearch.service.impl;
+
+import com.moviesearch.config.ProjectProperties;
+import com.moviesearch.service.DockerComposeRunner;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class DockerComposeRunnerImpl implements DockerComposeRunner {
+
+    @FunctionalInterface
+    interface ProcessLauncher {
+        Process launch(List<String> cmd, Path workingDir) throws IOException;
+    }
+
+    private final ProjectProperties projectProperties;
+    private final ProcessLauncher processLauncher;
+
+    public DockerComposeRunnerImpl(ProjectProperties projectProperties) {
+        this(projectProperties,
+                (cmd, dir) -> new ProcessBuilder(cmd).directory(dir.toFile()).redirectErrorStream(true).start());
+    }
+
+    DockerComposeRunnerImpl(ProjectProperties projectProperties, ProcessLauncher processLauncher) {
+        this.projectProperties = projectProperties;
+        this.processLauncher = processLauncher;
+    }
+
+    @Override
+    public void run(String... args) throws IOException, InterruptedException {
+        List<String> cmd = new ArrayList<>();
+        cmd.add("docker");
+        cmd.add("compose");
+        for (String arg : args) cmd.add(arg);
+        Path workingDir = projectProperties.getRoot();
+        Process process = processLauncher.launch(cmd, workingDir);
+        int exitCode = process.waitFor();
+        if (exitCode != 0)
+            throw new IOException("docker compose exited with code: " + exitCode);
+    }
+}


### PR DESCRIPTION
## Summary
Adds the `DockerComposeRunner` interface and `DockerComposeRunnerImpl` service for running `docker compose` commands with a configurable working directory and testable `ProcessLauncher` seam.

## Changes
- `api/src/main/java/com/moviesearch/service/DockerComposeRunner.java` — new interface with `void run(String... args) throws IOException, InterruptedException`
- `api/src/main/java/com/moviesearch/service/impl/DockerComposeRunnerImpl.java` — `@Service` implementation that prepends `["docker", "compose"]`, sets working dir to `projectProperties.getRoot()`, and throws `IOException` on non-zero exit

## Verification
All acceptance criteria from #47 verified before opening this PR.

Closes #47