### PR TITLE
Implement QdrantServiceManagerImpl and demote MockQdrantServiceManager

### DIFF
--- a/api/src/main/java/com/moviesearch/config/QdrantProperties.java
+++ b/api/src/main/java/com/moviesearch/config/QdrantProperties.java
@@ -1,10 +1,14 @@
 package com.moviesearch.config;
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "qdrant")
 public class QdrantProperties {
 
+    @NotBlank
     private String baseUrl = "http://localhost:6333";
     private boolean mock = false;
 

--- a/api/src/main/java/com/moviesearch/service/impl/DockerComposeRunnerImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/DockerComposeRunnerImpl.java
@@ -2,6 +2,7 @@ package com.moviesearch.service.impl;
 
 import com.moviesearch.config.ProjectProperties;
 import com.moviesearch.service.DockerComposeRunner;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -20,6 +21,7 @@ public class DockerComposeRunnerImpl implements DockerComposeRunner {
     private final ProjectProperties projectProperties;
     private final ProcessLauncher processLauncher;
 
+    @Autowired
     public DockerComposeRunnerImpl(ProjectProperties projectProperties) {
         this(projectProperties,
                 (cmd, dir) -> new ProcessBuilder(cmd).directory(dir.toFile()).redirectErrorStream(true).start());

--- a/api/src/main/java/com/moviesearch/service/impl/MockQdrantServiceManager.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockQdrantServiceManager.java
@@ -2,9 +2,7 @@ package com.moviesearch.service.impl;
 
 import com.moviesearch.model.ServiceStatus;
 import com.moviesearch.service.QdrantServiceManager;
-import org.springframework.stereotype.Service;
 
-@Service
 public class MockQdrantServiceManager implements QdrantServiceManager {
 
     private volatile ServiceStatus status = ServiceStatus.STOPPED;

--- a/api/src/main/java/com/moviesearch/service/impl/QdrantServiceManagerImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/QdrantServiceManagerImpl.java
@@ -1,0 +1,72 @@
+package com.moviesearch.service.impl;
+
+import com.moviesearch.config.QdrantProperties;
+import com.moviesearch.exception.QdrantServiceException;
+import com.moviesearch.model.ServiceStatus;
+import com.moviesearch.service.DockerComposeRunner;
+import com.moviesearch.service.QdrantServiceManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+@Service
+public class QdrantServiceManagerImpl implements QdrantServiceManager {
+
+    private final DockerComposeRunner dockerComposeRunner;
+    private final HttpClient httpClient;
+    private final QdrantProperties qdrantProperties;
+
+    @Autowired
+    public QdrantServiceManagerImpl(DockerComposeRunner dockerComposeRunner, QdrantProperties qdrantProperties) {
+        this(dockerComposeRunner, HttpClient.newHttpClient(), qdrantProperties);
+    }
+
+    QdrantServiceManagerImpl(DockerComposeRunner dockerComposeRunner, HttpClient httpClient, QdrantProperties qdrantProperties) {
+        this.dockerComposeRunner = dockerComposeRunner;
+        this.httpClient = httpClient;
+        this.qdrantProperties = qdrantProperties;
+    }
+
+    @Override
+    public void start() {
+        try {
+            dockerComposeRunner.run("up", "-d", "qdrant");
+        } catch (IOException e) {
+            throw new QdrantServiceException(QdrantServiceException.START_FAILED, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new QdrantServiceException(QdrantServiceException.START_FAILED, e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        try {
+            dockerComposeRunner.run("stop", "qdrant");
+        } catch (IOException e) {
+            throw new QdrantServiceException(QdrantServiceException.STOP_FAILED, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new QdrantServiceException(QdrantServiceException.STOP_FAILED, e);
+        }
+    }
+
+    @Override
+    public ServiceStatus getStatus() {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(qdrantProperties.getBaseUrl() + "/health"))
+                    .GET()
+                    .build();
+            HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+            return response.statusCode() == 200 ? ServiceStatus.RUNNING : ServiceStatus.STOPPED;
+        } catch (Exception e) {
+            return ServiceStatus.STOPPED;
+        }
+    }
+}

--- a/api/src/test/java/com/moviesearch/service/impl/QdrantServiceManagerImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/QdrantServiceManagerImplTest.java
@@ -1,0 +1,168 @@
+package com.moviesearch.service.impl;
+
+import com.moviesearch.config.QdrantProperties;
+import com.moviesearch.exception.QdrantServiceException;
+import com.moviesearch.model.ServiceStatus;
+import com.moviesearch.service.DockerComposeRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QdrantServiceManagerImplTest {
+
+    @Mock
+    private DockerComposeRunner dockerComposeRunner;
+
+    @Mock
+    private HttpClient httpClient;
+
+    @Mock
+    private HttpResponse<Void> httpResponse;
+
+    private QdrantProperties qdrantProperties;
+    private QdrantServiceManagerImpl manager;
+
+    @BeforeEach
+    void setUp() {
+        qdrantProperties = new QdrantProperties();
+        qdrantProperties.setBaseUrl("http://localhost:6333");
+        manager = new QdrantServiceManagerImpl(dockerComposeRunner, httpClient, qdrantProperties);
+    }
+
+    @Test
+    void start_callsDockerComposeUpDQdrant() throws IOException, InterruptedException {
+        manager.start();
+
+        verify(dockerComposeRunner).run("up", "-d", "qdrant");
+    }
+
+    @Test
+    void stop_callsDockerComposeStopQdrant() throws IOException, InterruptedException {
+        manager.stop();
+
+        verify(dockerComposeRunner).run("stop", "qdrant");
+    }
+
+    @Test
+    void start_ioException_throwsQdrantServiceExceptionWithStartFailed() throws IOException, InterruptedException {
+        IOException cause = new IOException("process failed");
+        doThrow(cause).when(dockerComposeRunner).run("up", "-d", "qdrant");
+
+        assertThatThrownBy(() -> manager.start())
+                .isInstanceOf(QdrantServiceException.class)
+                .hasMessage(QdrantServiceException.START_FAILED)
+                .hasCause(cause);
+    }
+
+    @Test
+    void start_interruptedException_throwsQdrantServiceExceptionAndSetsInterruptFlag() throws IOException, InterruptedException {
+        InterruptedException cause = new InterruptedException("interrupted");
+        doThrow(cause).when(dockerComposeRunner).run("up", "-d", "qdrant");
+
+        assertThatThrownBy(() -> manager.start())
+                .isInstanceOf(QdrantServiceException.class)
+                .hasMessage(QdrantServiceException.START_FAILED)
+                .hasCause(cause);
+
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        Thread.interrupted(); // clear for other tests
+    }
+
+    @Test
+    void stop_ioException_throwsQdrantServiceExceptionWithStopFailed() throws IOException, InterruptedException {
+        IOException cause = new IOException("process failed");
+        doThrow(cause).when(dockerComposeRunner).run("stop", "qdrant");
+
+        assertThatThrownBy(() -> manager.stop())
+                .isInstanceOf(QdrantServiceException.class)
+                .hasMessage(QdrantServiceException.STOP_FAILED)
+                .hasCause(cause);
+    }
+
+    @Test
+    void stop_interruptedException_throwsQdrantServiceExceptionAndSetsInterruptFlag() throws IOException, InterruptedException {
+        InterruptedException cause = new InterruptedException("interrupted");
+        doThrow(cause).when(dockerComposeRunner).run("stop", "qdrant");
+
+        assertThatThrownBy(() -> manager.stop())
+                .isInstanceOf(QdrantServiceException.class)
+                .hasMessage(QdrantServiceException.STOP_FAILED)
+                .hasCause(cause);
+
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        Thread.interrupted(); // clear for other tests
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getStatus_http200_returnsRunning() throws IOException, InterruptedException {
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponse);
+
+        assertThat(manager.getStatus()).isEqualTo(ServiceStatus.RUNNING);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getStatus_http503_returnsStopped() throws IOException, InterruptedException {
+        when(httpResponse.statusCode()).thenReturn(503);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponse);
+
+        assertThat(manager.getStatus()).isEqualTo(ServiceStatus.STOPPED);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getStatus_http404_returnsStopped() throws IOException, InterruptedException {
+        when(httpResponse.statusCode()).thenReturn(404);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponse);
+
+        assertThat(manager.getStatus()).isEqualTo(ServiceStatus.STOPPED);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getStatus_ioException_returnsStopped() throws IOException, InterruptedException {
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new IOException("connection refused"));
+
+        assertThat(manager.getStatus()).isEqualTo(ServiceStatus.STOPPED);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getStatus_interruptedException_returnsStopped() throws IOException, InterruptedException {
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new InterruptedException("interrupted"));
+
+        assertThat(manager.getStatus()).isEqualTo(ServiceStatus.STOPPED);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getStatus_usesHealthEndpoint() throws IOException, InterruptedException {
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponse);
+
+        manager.getStatus();
+
+        verify(httpClient).send(
+                org.mockito.ArgumentMatchers.argThat(req -> req.uri().toString().equals("http://localhost:6333/health")),
+                any(HttpResponse.BodyHandler.class));
+    }
+}


### PR DESCRIPTION
## Summary
Adds `QdrantServiceManagerImpl` as the production implementation of `QdrantServiceManager`, demotes `MockQdrantServiceManager` (removes `@Service`), and adds `@NotBlank`/`@Validated` validation to `QdrantProperties.baseUrl`.

## Changes
- `api/src/main/java/com/moviesearch/service/impl/QdrantServiceManagerImpl.java` — created with `start()`, `stop()`, `getStatus()` using `DockerComposeRunner` and `HttpClient`
- `api/src/main/java/com/moviesearch/service/impl/MockQdrantServiceManager.java` — removed `@Service` annotation
- `api/src/main/java/com/moviesearch/config/QdrantProperties.java` — added `@Validated` + `@NotBlank` on `baseUrl`
- `api/src/main/java/com/moviesearch/service/impl/DockerComposeRunnerImpl.java` — added `@Autowired` to public constructor (pre-existing bug: Spring couldn't resolve constructor with two non-annotated overloads)
- `api/src/test/java/com/moviesearch/service/impl/QdrantServiceManagerImplTest.java` — 12 unit tests covering all acceptance criteria

## Verification
All acceptance criteria from #49 verified before opening this PR.

Closes #49