### PR TITLE
Docs: Create feature-6 spec HTML pages (DockerComposeConfig, MakefileAndEnv, TritonModelRepository)

### DIFF
--- a/docs/specs/feature-6/DockerComposeConfig.html
+++ b/docs/specs/feature-6/DockerComposeConfig.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — DockerComposeConfig</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .diagram-container { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 24px; overflow: auto; }
+  .diagram-container svg { display: block; margin: 0 auto; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .code-block { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px 20px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.82rem; color: #e6edf3; overflow-x: auto; line-height: 1.6; margin-top: 8px; }
+  .code-block .kw { color: #ff7b72; }
+  .code-block .an { color: #f2cc60; }
+  .code-block .cm { color: #8b949e; font-style: italic; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+
+  #tooltip {
+    position: fixed; z-index: 9999; background: #1c2128; border: 1px solid #388bfd;
+    border-radius: 8px; padding: 12px 16px; max-width: 320px; pointer-events: none;
+    opacity: 0; transition: opacity 0.15s; box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  }
+  #tooltip.visible { opacity: 1; }
+  #tooltip .tip-title { font-weight: 600; font-size: 0.9rem; color: #79c0ff; margin-bottom: 6px; }
+  #tooltip .tip-body { font-size: 0.82rem; color: #c9d1d9; line-height: 1.5; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="../../index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / DockerComposeConfig</span>
+</header>
+
+<main>
+  <h2>DockerComposeConfig</h2>
+  <p class="subtitle">Documents <code>docker-compose.yml</code> at the repo root — defines the three services (Triton, Qdrant, API) and their wiring.</p>
+
+  <h3>Services</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Service</th><th>Image</th><th>Ports</th><th>Healthcheck endpoint</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>triton</td>
+        <td><code>nvcr.io/nvidia/tritonserver:24.01-py3</code></td>
+        <td>8000, 8001, 8002</td>
+        <td><code>GET :8000/v2/health/ready</code></td>
+      </tr>
+      <tr>
+        <td>qdrant</td>
+        <td><code>qdrant/qdrant:v1.9.2</code></td>
+        <td>6333, 6334</td>
+        <td><code>GET :6333/healthz</code></td>
+      </tr>
+      <tr>
+        <td>api</td>
+        <td>built from <code>Dockerfile</code></td>
+        <td>8080</td>
+        <td>—</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Service Details</h3>
+
+  <h3 style="margin-top:16px;">triton</h3>
+  <p style="color:#8b949e;font-size:0.9rem;line-height:1.6;margin-top:8px;">
+    Mounts <code>./model-repository:/models</code>. Exposes HTTP (8000), gRPC (8001), and metrics (8002) ports.
+    The healthcheck polls <code>GET :8000/v2/health/ready</code> to confirm the model is loaded before dependent services start.
+  </p>
+
+  <h3>qdrant</h3>
+  <p style="color:#8b949e;font-size:0.9rem;line-height:1.6;margin-top:8px;">
+    Uses named volume <code>qdrant_data:/qdrant/storage</code> to persist the vector index across restarts.
+    Exposes REST (6333) and gRPC (6334) ports. The healthcheck polls <code>GET :6333/healthz</code>.
+  </p>
+
+  <h3>api</h3>
+  <p style="color:#8b949e;font-size:0.9rem;line-height:1.6;margin-top:8px;">
+    Built from the repo-root <code>Dockerfile</code>. Exposed on port 8080.
+    Declares <code>depends_on</code> for both <code>triton</code> and <code>qdrant</code> with <code>condition: service_healthy</code>,
+    ensuring the API container only starts after both backends pass their healthchecks.
+  </p>
+
+  <h3>Dependency Ordering</h3>
+  <p style="color:#8b949e;font-size:0.9rem;line-height:1.6;margin-top:8px;">
+    Docker Compose starts <code>triton</code> and <code>qdrant</code> in parallel, waits for both to report healthy, then starts <code>api</code>.
+    This guarantees that the Spring Boot application can connect to Triton on gRPC port 8001 and Qdrant on REST port 6333 immediately on startup.
+  </p>
+
+  <h3>Named Volumes</h3>
+  <div class="code-block">
+<span class="kw">volumes</span>:
+  qdrant_data: {}
+  </div>
+  <p style="color:#8b949e;font-size:0.875rem;margin-top:8px;">
+    The <code>qdrant_data</code> volume is declared at the top level so Docker manages its lifecycle independently of the container.
+    It is removed only when <code>make clean</code> runs <code>docker compose down -v</code>.
+  </p>
+
+  <a class="back-link" href="../../index.html">← Back to Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+<div id="tooltip"><div class="tip-title" id="tip-title"></div><div class="tip-body" id="tip-body"></div></div>
+
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+
+mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'loose' });
+
+await mermaid.run();
+</script>
+</body>
+</html>

--- a/docs/specs/feature-6/MakefileAndEnv.html
+++ b/docs/specs/feature-6/MakefileAndEnv.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — MakefileAndEnv</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .diagram-container { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 24px; overflow: auto; }
+  .diagram-container svg { display: block; margin: 0 auto; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .code-block { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px 20px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.82rem; color: #e6edf3; overflow-x: auto; line-height: 1.6; margin-top: 8px; }
+  .code-block .kw { color: #ff7b72; }
+  .code-block .an { color: #f2cc60; }
+  .code-block .cm { color: #8b949e; font-style: italic; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+
+  #tooltip {
+    position: fixed; z-index: 9999; background: #1c2128; border: 1px solid #388bfd;
+    border-radius: 8px; padding: 12px 16px; max-width: 320px; pointer-events: none;
+    opacity: 0; transition: opacity 0.15s; box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  }
+  #tooltip.visible { opacity: 1; }
+  #tooltip .tip-title { font-weight: 600; font-size: 0.9rem; color: #79c0ff; margin-bottom: 6px; }
+  #tooltip .tip-body { font-size: 0.82rem; color: #c9d1d9; line-height: 1.5; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="../../index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / MakefileAndEnv</span>
+</header>
+
+<main>
+  <h2>MakefileAndEnv</h2>
+  <p class="subtitle">Documents <code>Makefile</code> and <code>.env.example</code> at the repo root — convenience targets for managing the Docker Compose stack and the data pipeline.</p>
+
+  <h3>Makefile Targets</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Target</th><th>Command(s)</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>up</td>
+        <td><code>docker compose up -d</code></td>
+        <td>Start all services in detached mode.</td>
+      </tr>
+      <tr>
+        <td>down</td>
+        <td><code>docker compose down</code></td>
+        <td>Stop and remove containers (volumes retained).</td>
+      </tr>
+      <tr>
+        <td>pipeline</td>
+        <td><code>pip install -r requirements.txt</code> then scripts 01–05 in order</td>
+        <td>Install Python dependencies and run all five pipeline steps end-to-end.</td>
+      </tr>
+      <tr>
+        <td>clean</td>
+        <td>Remove model artefacts and data dirs, then <code>docker compose down -v</code></td>
+        <td>Full teardown: wipe generated files and destroy named volumes.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Pipeline Target Detail</h3>
+  <p style="color:#8b949e;font-size:0.9rem;line-height:1.6;margin-top:8px;">
+    The <code>pipeline</code> target first installs Python dependencies from <code>requirements.txt</code>, then executes pipeline scripts
+    <code>01_fetch_tmdb.py</code> through <code>05_enrich_tmdb.py</code> in strict order. Each script produces output consumed by the next.
+  </p>
+
+  <h3>Clean Target Detail</h3>
+  <p style="color:#8b949e;font-size:0.9rem;line-height:1.6;margin-top:8px;">
+    The <code>clean</code> target removes generated model artefacts from <code>model-repository/all-minilm-l6-v2/1/</code>
+    and all pipeline data directories, then runs <code>docker compose down -v</code> to destroy the <code>qdrant_data</code> named volume.
+    Use this to reset the entire environment to a clean state.
+  </p>
+
+  <h3>Environment Variables (<code>.env.example</code>)</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Variable</th><th>Description</th><th>Required</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>TMDB_API_KEY</td>
+        <td>API key for The Movie Database; used by <code>pipeline/05_enrich_tmdb.py</code> to fetch movie metadata.</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>PROJECT_ROOT</td>
+        <td>Absolute path to the repository root; used by pipeline scripts to resolve data and model directory paths.</td>
+        <td>Yes</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p style="color:#8b949e;font-size:0.875rem;margin-top:8px;">
+    Copy <code>.env.example</code> to <code>.env</code> and populate both values before running <code>make pipeline</code>.
+    The <code>.env</code> file is gitignored to prevent accidental credential commits.
+  </p>
+
+  <a class="back-link" href="../../index.html">← Back to Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+<div id="tooltip"><div class="tip-title" id="tip-title"></div><div class="tip-body" id="tip-body"></div></div>
+
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+
+mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'loose' });
+
+await mermaid.run();
+</script>
+</body>
+</html>

--- a/docs/specs/feature-6/TritonModelRepository.html
+++ b/docs/specs/feature-6/TritonModelRepository.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — TritonModelRepository</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .diagram-container { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 24px; overflow: auto; }
+  .diagram-container svg { display: block; margin: 0 auto; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .code-block { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px 20px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.82rem; color: #e6edf3; overflow-x: auto; line-height: 1.6; margin-top: 8px; }
+  .code-block .kw { color: #ff7b72; }
+  .code-block .an { color: #f2cc60; }
+  .code-block .cm { color: #8b949e; font-style: italic; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+
+  #tooltip {
+    position: fixed; z-index: 9999; background: #1c2128; border: 1px solid #388bfd;
+    border-radius: 8px; padding: 12px 16px; max-width: 320px; pointer-events: none;
+    opacity: 0; transition: opacity 0.15s; box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  }
+  #tooltip.visible { opacity: 1; }
+  #tooltip .tip-title { font-weight: 600; font-size: 0.9rem; color: #79c0ff; margin-bottom: 6px; }
+  #tooltip .tip-body { font-size: 0.82rem; color: #c9d1d9; line-height: 1.5; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="../../index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / TritonModelRepository</span>
+</header>
+
+<main>
+  <h2>TritonModelRepository</h2>
+  <p class="subtitle">Documents <code>model-repository/all-minilm-l6-v2/config.pbtxt</code> — the Triton Inference Server configuration for the sentence-embedding model.</p>
+
+  <h3>Model Config (<code>config.pbtxt</code>)</h3>
+  <div class="code-block">
+name: "all-minilm-l6-v2"
+backend: "python"
+
+input  [ { name: "TEXT",               data_type: TYPE_BYTES, dims: [1]   } ]
+output [ { name: "sentence_embedding", data_type: TYPE_FP32,  dims: [384] } ]
+
+dynamic_batching {
+  preferred_batch_size: [8, 16]
+  max_queue_delay_microseconds: 5000
+}
+  </div>
+
+  <h3>Input / Output Tensors</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Direction</th><th>Name</th><th>Data Type</th><th>Dims</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>input</td>
+        <td>TEXT</td>
+        <td><code>TYPE_BYTES</code></td>
+        <td><code>[1]</code></td>
+        <td>Raw UTF-8 text string to embed, length-prefixed per Triton binary protocol.</td>
+      </tr>
+      <tr>
+        <td>output</td>
+        <td>sentence_embedding</td>
+        <td><code>TYPE_FP32</code></td>
+        <td><code>[384]</code></td>
+        <td>384-dimensional float32 embedding vector produced by all-MiniLM-L6-v2.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Dynamic Batching</h3>
+  <p style="color:#8b949e;font-size:0.9rem;line-height:1.6;margin-top:8px;">
+    Triton batches concurrent inference requests before forwarding them to the Python backend.
+    Preferred batch sizes are 8 and 16. If a full batch is not available within 5 ms
+    (<code>max_queue_delay_microseconds: 5000</code>), the partial batch is dispatched immediately.
+    This keeps tail latency bounded while improving GPU/CPU throughput under load.
+  </p>
+
+  <h3>Model Directory Layout</h3>
+  <p style="color:#8b949e;font-size:0.9rem;line-height:1.6;margin-top:8px;">
+    Triton requires a versioned subdirectory under the model name:
+  </p>
+  <div class="code-block">
+model-repository/
+  all-minilm-l6-v2/
+    config.pbtxt          <span class="cm"># model configuration (committed)</span>
+    1/                    <span class="cm"># version directory</span>
+      model.onnx          <span class="cm"># generated by pipeline/02_export_onnx.py (gitignored)</span>
+      model.py            <span class="cm"># Python backend entry point (committed)</span>
+  </div>
+  <p style="color:#8b949e;font-size:0.875rem;margin-top:8px;">
+    <code>model-repository/all-minilm-l6-v2/1/model.onnx</code> is generated by pipeline step 02 and is gitignored.
+    Run <code>make pipeline</code> (or <code>python pipeline/02_export_onnx.py</code> directly) to produce it before starting Triton.
+  </p>
+
+  <a class="back-link" href="../../index.html">← Back to Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+<div id="tooltip"><div class="tip-title" id="tip-title"></div><div class="tip-body" id="tip-body"></div></div>
+
+<script type="module">
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+
+mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'loose' });
+
+await mermaid.run();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Creates three dark-themed HTML spec pages for Feature #6 (Docker Compose Infrastructure) under `docs/specs/feature-6/`.

## Changes
- `docs/specs/feature-6/DockerComposeConfig.html` — documents the three Docker Compose services (triton, qdrant, api) with a service table and dependency ordering note
- `docs/specs/feature-6/MakefileAndEnv.html` — documents all four Makefile targets and both `.env.example` variables with a required/description table
- `docs/specs/feature-6/TritonModelRepository.html` — documents the Triton `config.pbtxt` tensors, dynamic batching config, and model directory layout

## Verification
All acceptance criteria from #82 verified before opening this PR.

Closes #82