### PR TITLE
Docs integration: add Feature #6 Docker Compose Infrastructure nav links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,7 @@
   .nav-links { display: flex; gap: 16px; margin-top: 24px; flex-wrap: wrap; }
   .nav-links a { background: #21262d; border: 1px solid #30363d; border-radius: 6px; padding: 8px 16px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; transition: background 0.15s; }
   .nav-links a:hover { background: #30363d; }
+  .section-heading { font-size: 1rem; font-weight: 600; color: #8b949e; margin-top: 28px; margin-bottom: 8px; }
   footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
 
   /* Tooltip */
@@ -80,6 +81,13 @@ flowchart TB
     <a href="EmbeddingServiceImpl.html">EmbeddingServiceImpl →</a>
     <a href="qdrant-properties.html">QdrantProperties →</a>
     <a href="VectorSearchServiceImpl.html">VectorSearchServiceImpl →</a>
+  </div>
+
+  <h3 class="section-heading">Feature #6: Docker Compose Infrastructure</h3>
+  <div class="nav-links">
+    <a href="specs/feature-6/DockerComposeConfig.html">DockerComposeConfig →</a>
+    <a href="specs/feature-6/MakefileAndEnv.html">MakefileAndEnv →</a>
+    <a href="specs/feature-6/TritonModelRepository.html">TritonModelRepository →</a>
   </div>
 </main>
 


### PR DESCRIPTION
## Summary
Adds navigation links for the three Feature #6 Docker Compose Infrastructure spec pages under a dedicated section in `docs/index.html`.

## Changes
- `docs/index.html` — added `.section-heading` style and a "Feature #6: Docker Compose Infrastructure" section with links to `DockerComposeConfig.html`, `MakefileAndEnv.html`, and `TritonModelRepository.html`

## Verification
All acceptance criteria from #60 verified before opening this PR.

Closes #60