### PR TITLE
Fix ProjectPropertiesTest: store root as String to prevent path resolution

### DIFF
--- a/api/src/main/java/com/moviesearch/config/ProjectProperties.java
+++ b/api/src/main/java/com/moviesearch/config/ProjectProperties.java
@@ -1,6 +1,6 @@
 package com.moviesearch.config;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -10,14 +10,14 @@ import java.nio.file.Path;
 @ConfigurationProperties(prefix = "project")
 public class ProjectProperties {
 
-    @NotNull
-    private Path root;
+    @NotBlank
+    private String root;
 
     public Path getRoot() {
-        return root;
+        return Path.of(root);
     }
 
-    public void setRoot(Path root) {
+    public void setRoot(String root) {
         this.root = root;
     }
 }

--- a/api/src/test/java/com/moviesearch/service/step/impl/GenerateEmbeddingsServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/step/impl/GenerateEmbeddingsServiceImplTest.java
@@ -40,7 +40,7 @@ class GenerateEmbeddingsServiceImplTest {
     @BeforeEach
     void setUp() {
         ProjectProperties props = new ProjectProperties();
-        props.setRoot(tempDir);
+        props.setRoot(tempDir.toString());
         service = new GenerateEmbeddingsServiceImpl(pythonScriptRunner, props);
     }
 

--- a/api/src/test/java/com/moviesearch/service/step/impl/IngestIntoQdrantServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/step/impl/IngestIntoQdrantServiceImplTest.java
@@ -48,7 +48,7 @@ class IngestIntoQdrantServiceImplTest {
     @BeforeEach
     void setUp() {
         ProjectProperties projectProps = new ProjectProperties();
-        projectProps.setRoot(tempDir);
+        projectProps.setRoot(tempDir.toString());
 
         QdrantProperties qdrantProps = new QdrantProperties();
         qdrantProps.setBaseUrl("http://qdrant.local:6333");


### PR DESCRIPTION
## Summary
Fix `ProjectPropertiesTest.relativePathBindsCorrectly` by storing `project.root` as a `String` instead of `Path`, preventing Spring from resolving relative paths against the working directory at context startup.

## Changes
- `api/src/main/java/com/moviesearch/config/ProjectProperties.java` — change `root` field from `Path` to `String`; `getRoot()` now returns `Path.of(root)` and `setRoot` accepts `String`; switch `@NotNull` to `@NotBlank`
- `api/src/test/java/com/moviesearch/service/step/impl/GenerateEmbeddingsServiceImplTest.java` — update `setRoot(tempDir)` to `setRoot(tempDir.toString())`
- `api/src/test/java/com/moviesearch/service/step/impl/IngestIntoQdrantServiceImplTest.java` — update `setRoot(tempDir)` to `setRoot(tempDir.toString())`

## Verification
All 197 tests pass (0 failures, 0 errors).

Closes #68