### PR TITLE
Add springdoc-openapi-starter-webmvc-ui to expose Swagger UI

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -73,6 +73,12 @@
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary
- Adds `springdoc-openapi-starter-webmvc-ui` v2.3.0 (groupId `org.springdoc`) to `api/pom.xml`
- Auto-configures Swagger UI at `/swagger-ui/index.html` and OpenAPI JSON at `/v3/api-docs` — no Java configuration needed
- Satisfies acceptance criteria for task #92 (part of feature #87 executive guide operator tools)

## Test plan
- [x] `./mvnw -f api/pom.xml test` passes â 204 tests, 0 failures
- [x] No existing tests broken

Closes #92

https://claude.ai/code/session_01Fj76Agv7d7brx7GDswA6yi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fj76Agv7d7brx7GDswA6yi)_