### PR TITLE
Add SwaggerUiIntegrationTest for Swagger UI and OpenAPI endpoints

### DIFF
--- a/api/src/test/java/com/moviesearch/integration/SwaggerUiIntegrationTest.java
+++ b/api/src/test/java/com/moviesearch/integration/SwaggerUiIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.moviesearch.integration;
+
+import com.moviesearch.service.DockerComposeRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SwaggerUiIntegrationTest {
+
+    @TempDir
+    static Path tempDir;
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("project.root", tempDir::toString);
+        registry.add("tmdb.api-key", () -> "test-key");
+    }
+
+    @MockBean
+    private DockerComposeRunner dockerComposeRunner;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void swaggerUiIndexHtml_returnsHttp200() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/swagger-ui/index.html", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void apiDocs_returnsHttp200WithOpenApiBody() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/v3/api-docs", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("openapi");
+    }
+}


### PR DESCRIPTION
## Summary
Adds `SwaggerUiIntegrationTest` to verify that the Swagger UI and OpenAPI docs endpoints are available after the springdoc-openapi dependency was added in feature #87.

## Changes
- `api/src/test/java/com/moviesearch/integration/SwaggerUiIntegrationTest.java` — new Spring Boot integration test asserting `GET /swagger-ui/index.html` returns HTTP 200 and `GET /v3/api-docs` returns HTTP 200 with a response body containing `"openapi"`

## Verification
All acceptance criteria from #94 verified before opening this PR.
- Integration tests implemented and cover the full feature flow (Swagger UI + OpenAPI endpoints)
- All 206 tests pass (0 failures, 0 errors)

Closes #94