### PR TITLE
Fix qdrant healthcheck: curl not available in qdrant image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,11 @@ services:
     volumes:
       - qdrant_data:/qdrant/storage
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:6333/healthz"]
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/6333 && echo -e 'GET /healthz HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && grep -q '200' <&3"]
       interval: 5s
       timeout: 3s
       retries: 6
+      start_period: 10s
 
   api:
     build: .
@@ -37,6 +38,12 @@ services:
         condition: service_healthy
       qdrant:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/api/operator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
 
 volumes:
   qdrant_data: {}


### PR DESCRIPTION
## Summary

- Replaces `curl` in the qdrant healthcheck with a `bash -c` `/dev/tcp` HTTP request — `curl` is not installed in the `qdrant/qdrant:v1.9.2` image, causing every health check to fail with "executable file not found"
- Adds `start_period: 10s` to the qdrant healthcheck as a defensive grace window during startup
- Adds a healthcheck to the `api` service using the existing `/api/operator/health` endpoint, with a 30s start period to allow Spring Boot to initialize

Closes #108

## Test plan

- [x] Ran `docker compose up -d` — all three containers (triton, qdrant, api) reached `healthy` status
- [x] Verified `docker compose ps` shows `(healthy)` for all services

🤖 Generated with [Claude Code](https://claude.com/claude-code)