### PR TITLE
Create pipeline/Dockerfile with python:3.11-slim base and all dependencies

### DIFF
--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# libgomp1 required by torch CPU wheels on slim images
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy pipeline scripts; tests are excluded
+COPY *.py .


### PR DESCRIPTION
## Summary
Creates `pipeline/Dockerfile` using `python:3.11-slim` as the base image, installs `libgomp1` and all Python dependencies from `requirements.txt`, and copies the five pipeline scripts into `/app` with no entrypoint set.

## Changes
- `pipeline/Dockerfile` — new file; defines the shared base image for all pipeline Compose services

## Verification
All acceptance criteria from #115 verified before opening this PR.

Closes #115