### PR TITLE
Fix Docker build: COPY *.py . → COPY *.py ./ in pipeline/Dockerfile

### DIFF
--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -11,4 +11,4 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy pipeline scripts; tests are excluded
-COPY *.py .
+COPY *.py ./


### PR DESCRIPTION
## Summary
Fixes the Docker build failure in `pipeline/Dockerfile` by changing `COPY *.py .` to `COPY *.py ./` so the destination is unambiguously a directory, which Docker requires when copying multiple source files.

## Changes
- `pipeline/Dockerfile` — changed `COPY *.py .` to `COPY *.py ./` on line 14

## Verification
All acceptance criteria from #119 verified before opening this PR. The fix resolves the Docker build error: `When using COPY with more than one source file, the destination must be a directory and end with a /`.

Closes #119