### PR TITLE
Update README.md and docs/arch/pipeline.md for two-phase workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,19 +211,14 @@ movie-semantic-search/
 ## Quick Start (for future reference)
 
 ```bash
-# 1. Start infrastructure (Triton + Qdrant)
-docker compose up triton qdrant -d
+# 1. Export the ONNX model (Phase 1 — run once before starting services)
+docker compose run --rm load-model
 
-# 2. Run offline pipeline (one time)
-cd pipeline
-pip install -r requirements.txt
-python 01_download_corpus.py
-python 02_export_model.py
-python 03_embed_corpus.py
-python 04_ingest_qdrant.py
+# 2. Start infrastructure (Triton + Qdrant + API)
+docker compose up -d
 
-# 3. Start the API
-docker compose up api -d
+# 3. Load the movie data (Phase 2 — run once after services are healthy)
+docker compose run --rm load-data
 
 # 4. Open the UI
 open http://localhost:8080
@@ -232,7 +227,7 @@ open http://localhost:8080
 Or with Make:
 
 ```bash
-make pipeline   # run all pipeline steps
+make pipeline   # export model, start services, load data
 make up         # start all services
 make down       # stop all services
 ```

--- a/docs/arch/pipeline.md
+++ b/docs/arch/pipeline.md
@@ -1,6 +1,6 @@
 # Pipeline Component
 
-Five Python scripts that build the search index. Run once before starting the serving stack. All scripts are idempotent.
+Five Python scripts that build the search index, executed in two phases. Scripts 01–02 (`load-model` phase) run before services start and export the ONNX model to the Triton model repository. Scripts 03–05 (`load-data` phase) run after services are healthy and require Triton and Qdrant to be reachable.
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
## Summary
Replaces the old single-command pipeline instructions in README.md and docs/arch/pipeline.md with the correct three-step two-phase sequence (`load-model` → `docker compose up -d` → `load-data`), fixing the pre-existing Triton sequencing bug.

## Changes
- `README.md` — replaced quick start bash block with four-step two-phase sequence; updated `make pipeline` comment to describe new orchestration
- `docs/arch/pipeline.md` — updated opening paragraph to describe two-phase execution model

## Verification
All acceptance criteria from #133 verified before opening this PR.

Closes #133