### PR TITLE
Add load-model and load-data services to docker-compose.yml and update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,3 @@
 
 # TMDB v3 API key — required by pipeline/05_enrich_tmdb.py for poster URL enrichment
 TMDB_API_KEY=your_tmdb_api_key_here
-
-# Absolute path to the repo root — used by pipeline scripts referencing data/ and model-repository/ directories
-PROJECT_ROOT=/path/to/movie-semantic-search

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,5 +45,25 @@ services:
       retries: 12
       start_period: 30s
 
+  load-model:
+    profiles: [load-model]
+    build: ./pipeline
+    volumes:
+      - ./data:/app/data
+      - ./model-repository:/app/model-repository
+
+  load-data:
+    profiles: [load-data]
+    build: ./pipeline
+    volumes:
+      - ./data:/app/data
+    env_file: .env
+    command: ["/app/load-data.sh"]
+    depends_on:
+      triton:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+
 volumes:
   qdrant_data: {}


### PR DESCRIPTION
## Summary
Adds `load-model` and `load-data` profile-gated services to `docker-compose.yml` and removes the stale `PROJECT_ROOT` variable from `.env.example`.

## Changes
- `docker-compose.yml` — added `load-model` service (profile-gated, mounts `data/` and `model-repository/`) and `load-data` service (profile-gated, depends on triton+qdrant healthy, uses `env_file: .env`, mounts `data/`)
- `.env.example` — removed unused `PROJECT_ROOT` variable and its comment

## Verification
All acceptance criteria from #125 verified before opening this PR.

Closes #125