### PR TITLE
Docs integration: Add load-model.sh, load-data.sh, and DockerComposeServices spec pages

### DIFF
--- a/docs/docker-compose-services.html
+++ b/docs/docker-compose-services.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — DockerComposeServices</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  h4 { font-size: 0.9rem; font-weight: 600; margin: 16px 0 6px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.78rem; font-weight: 600; background: #1f3d2e; color: #3fb950; border: 1px solid #2ea043; margin-bottom: 20px; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .code-block { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px 20px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.82rem; color: #e6edf3; overflow-x: auto; line-height: 1.6; margin-top: 8px; white-space: pre-wrap; word-break: break-all; }
+  .criteria-list { list-style: none; padding: 0; margin-top: 8px; }
+  .criteria-list li { display: flex; align-items: flex-start; gap: 10px; padding: 8px 0; border-bottom: 1px solid #21262d; font-size: 0.875rem; color: #c9d1d9; }
+  .criteria-list li:last-child { border-bottom: none; }
+  .criteria-list li::before { content: "☐"; color: #58a6ff; font-size: 1rem; flex-shrink: 0; line-height: 1.4; }
+  .callout { background: #161b22; border: 1px solid #30363d; border-left: 4px solid #388bfd; border-radius: 6px; padding: 14px 18px; margin-top: 14px; font-size: 0.875rem; color: #c9d1d9; line-height: 1.6; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+  p.prose { color: #8b949e; font-size: 0.9rem; line-height: 1.6; margin-top: 8px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / DockerComposeServices</span>
+</header>
+
+<main>
+  <h2>DockerComposeServices</h2>
+  <span class="badge">#112 — Add load-model and load-data services to docker-compose.yml</span>
+  <p class="subtitle">Two new one-shot compose services — <code>load-model</code> and <code>load-data</code> — gated behind profiles so they never auto-start. <code>load-model</code> exports the ONNX model; <code>load-data</code> embeds, ingests, and optionally enriches all movie data.</p>
+
+  <h3>Overview</h3>
+  <p class="prose">
+    Two new one-shot services — <code>load-model</code> and <code>load-data</code> — are added to <code>docker-compose.yml</code>. Both are gated behind Compose profiles so they never start automatically on <code>docker compose up -d</code>. <code>load-model</code> runs pipeline scripts 01–02 with no service dependencies, binding <code>data/</code> and <code>model-repository/</code> so outputs persist on the host. <code>load-data</code> depends on <code>triton</code> and <code>qdrant</code> being healthy, binds <code>data/</code> for read access, and passes <code>TMDB_API_KEY</code> from the <code>.env</code> file. Additionally, <code>.env.example</code> is updated to remove the stale <code>PROJECT_ROOT</code> variable.
+  </p>
+
+  <h3>Operator Commands</h3>
+  <p class="prose">These are the only commands operators use to invoke the two services. No other form is correct.</p>
+  <table class="prop-table" style="margin-top:12px;">
+    <thead>
+      <tr><th>Step</th><th>Command</th><th>When</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1 — Export model</td>
+        <td><code>docker compose run --rm load-model</code></td>
+        <td>Before starting the stack; exports ONNX model and downloads corpus</td>
+      </tr>
+      <tr>
+        <td>2 — Start the stack</td>
+        <td><code>docker compose up -d</code></td>
+        <td>After step 1; starts triton, qdrant, api — does NOT start load-model or load-data</td>
+      </tr>
+      <tr>
+        <td>3 — Load data</td>
+        <td><code>docker compose run --rm load-data</code></td>
+        <td>After step 2, once triton and qdrant are healthy</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout">
+    <strong>Why <code>docker compose run</code> works without <code>--profile</code>:</strong> <code>docker compose run</code> bypasses profile filtering — it starts a named service directly regardless of its <code>profiles</code> key. Profiles only affect <code>docker compose up</code>. So <code>docker compose run --rm load-model</code> is the correct invocation; adding <code>--profile load-model</code> is unnecessary and misleading.
+  </div>
+
+  <h3>Data Contract</h3>
+
+  <h4>load-model service</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Property</th><th>Value</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>profiles</td>
+        <td><code>[load-model]</code></td>
+        <td>Prevents auto-start on <code>docker compose up -d</code>; invoke with <code>docker compose run --rm load-model</code></td>
+      </tr>
+      <tr>
+        <td>build</td>
+        <td><code>./pipeline</code></td>
+        <td>Build context pointing to <code>pipeline/Dockerfile</code></td>
+      </tr>
+      <tr>
+        <td>volumes</td>
+        <td><code>./data:/app/data</code>, <code>./model-repository:/app/model-repository</code></td>
+        <td>Host-persist model and data outputs</td>
+      </tr>
+      <tr>
+        <td>entrypoint (implicit)</td>
+        <td>Defined in <code>pipeline/Dockerfile</code> CMD/ENTRYPOINT</td>
+        <td>Should resolve to <code>/app/load-model.sh</code></td>
+      </tr>
+      <tr>
+        <td>depends_on</td>
+        <td>none</td>
+        <td>Runs before Triton starts</td>
+      </tr>
+      <tr>
+        <td>restart</td>
+        <td><code>no</code> (default)</td>
+        <td>One-shot; must not restart on failure</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>load-data service</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Property</th><th>Value</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>profiles</td>
+        <td><code>[load-data]</code></td>
+        <td>Prevents auto-start on <code>docker compose up -d</code>; invoke with <code>docker compose run --rm load-data</code></td>
+      </tr>
+      <tr>
+        <td>build</td>
+        <td><code>./pipeline</code></td>
+        <td>Same image as <code>load-model</code></td>
+      </tr>
+      <tr>
+        <td>volumes</td>
+        <td><code>./data:/app/data</code></td>
+        <td>Reads embeddings written by <code>load-model</code></td>
+      </tr>
+      <tr>
+        <td>env_file</td>
+        <td><code>.env</code></td>
+        <td>Passes all vars from <code>.env</code>, including <code>TMDB_API_KEY</code></td>
+      </tr>
+      <tr>
+        <td>depends_on</td>
+        <td><code>triton: service_healthy</code>, <code>qdrant: service_healthy</code></td>
+        <td>Will not start until both pass healthcheck</td>
+      </tr>
+      <tr>
+        <td>restart</td>
+        <td><code>no</code> (default)</td>
+        <td>One-shot</td>
+      </tr>
+      <tr>
+        <td>command</td>
+        <td><code>["/app/load-data.sh"]</code></td>
+        <td>Overrides CMD to run the load-data entrypoint</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>.env.example</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Property</th><th>Before</th><th>After</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>PROJECT_ROOT</td>
+        <td><code>"Absolute path to the repo root — used by pipeline scripts referencing data/ and model-repository/ directories"</code></td>
+        <td>Line removed entirely (variable is unused by pipeline scripts)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Dependencies</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Dependency</th><th>Interface / Type</th><th>Injected As</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>pipeline/Dockerfile</td>
+        <td>Docker build context</td>
+        <td>Referenced via <code>build: ./pipeline</code> (from sibling feature #111)</td>
+      </tr>
+      <tr>
+        <td>triton service</td>
+        <td>Compose service with <code>service_healthy</code> condition</td>
+        <td><code>depends_on</code> in <code>load-data</code></td>
+      </tr>
+      <tr>
+        <td>qdrant service</td>
+        <td>Compose service with <code>service_healthy</code> condition</td>
+        <td><code>depends_on</code> in <code>load-data</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>triton service — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Mock Setup</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Healthy</td><td>Triton passes its healthcheck</td><td><code>load-data</code> is allowed to start</td></tr>
+      <tr><td>Unhealthy / not started</td><td>Triton fails healthcheck</td><td><code>load-data</code> is blocked by Compose before the container runs at all</td></tr>
+    </tbody>
+  </table>
+
+  <h4>qdrant service — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Mock Setup</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Healthy</td><td>Qdrant passes its healthcheck</td><td><code>load-data</code> is allowed to start</td></tr>
+      <tr><td>Unhealthy / not started</td><td>Qdrant fails healthcheck</td><td><code>load-data</code> is blocked by Compose</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Edge Cases</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>#</th><th>Input</th><th>Expected Output</th><th>Description</th><th>Mock Setup</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td><code>docker compose up -d</code></td>
+        <td><code>load-model</code> and <code>load-data</code> containers are NOT started</td>
+        <td>Profile gate prevents auto-start</td>
+        <td>Run without any <code>--profile</code> flag</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td><code>docker compose run --rm load-model</code></td>
+        <td>Container starts, runs 01+02, exits</td>
+        <td>Correct operator invocation for step 1</td>
+        <td>No service dependencies required</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td><code>docker compose run --rm load-data</code> with triton and qdrant healthy</td>
+        <td>Container starts, runs 03–05 (or skips 05), exits</td>
+        <td>Correct operator invocation for step 3</td>
+        <td>Triton and Qdrant healthy</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td><code>docker compose run --rm load-data</code> with triton or qdrant unhealthy</td>
+        <td>Compose blocks start (<code>depends_on</code> not met)</td>
+        <td><code>depends_on: service_healthy</code> enforced by Compose</td>
+        <td>Triton or Qdrant not passing healthcheck</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td>After <code>docker compose run --rm load-model</code>, <code>./data/</code> and <code>./model-repository/</code> contain outputs</td>
+        <td>Files visible on the host</td>
+        <td>Volume bind-mounts work</td>
+        <td>load-model succeeds</td>
+      </tr>
+      <tr>
+        <td>6</td>
+        <td><code>.env</code> contains <code>TMDB_API_KEY=abc123</code></td>
+        <td>Variable available inside load-data container</td>
+        <td><code>env_file</code> passthrough</td>
+        <td><code>.env</code> file present</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Unit Test Checklist</h3>
+  <p class="prose">Compose service definitions are not Python-testable. All behavior is verified by the integration test task:</p>
+  <ul class="criteria-list" style="margin-top:12px;">
+    <li><code>docker compose up -d</code> does not start <code>load-model</code> or <code>load-data</code></li>
+    <li><code>load-model</code> service mounts <code>./data</code> and <code>./model-repository</code> as <code>rw</code> volumes</li>
+    <li><code>load-data</code> service <code>depends_on</code> triton and qdrant with <code>service_healthy</code> condition</li>
+    <li><code>load-data</code> service passes <code>TMDB_API_KEY</code> from <code>.env</code> via <code>env_file</code></li>
+    <li><code>.env.example</code> no longer contains the <code>PROJECT_ROOT</code> variable</li>
+  </ul>
+
+  <a class="back-link" href="index.html">← Back to Architecture Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,6 +111,14 @@ flowchart TB
   <div class="nav-links">
     <a href="specs/feature-88/WalkthroughSection.html">WalkthroughSection →</a>
   </div>
+
+  <h2 style="margin-top:48px;">Feature #112 — Load-Model and Load-Data Compose Services</h2>
+  <p class="subtitle">Two one-shot Docker Compose services for running the pipeline without a local Python install.</p>
+  <div class="nav-links">
+    <a href="load-model-sh.html">load-model.sh →</a>
+    <a href="load-data-sh.html">load-data.sh →</a>
+    <a href="docker-compose-services.html">DockerComposeServices →</a>
+  </div>
 </main>
 
 <footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>

--- a/docs/load-data-sh.html
+++ b/docs/load-data-sh.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — load-data.sh</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  h4 { font-size: 0.9rem; font-weight: 600; margin: 16px 0 6px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.78rem; font-weight: 600; background: #1f3d2e; color: #3fb950; border: 1px solid #2ea043; margin-bottom: 20px; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .code-block { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px 20px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.82rem; color: #e6edf3; overflow-x: auto; line-height: 1.6; margin-top: 8px; white-space: pre-wrap; word-break: break-all; }
+  .criteria-list { list-style: none; padding: 0; margin-top: 8px; }
+  .criteria-list li { display: flex; align-items: flex-start; gap: 10px; padding: 8px 0; border-bottom: 1px solid #21262d; font-size: 0.875rem; color: #c9d1d9; }
+  .criteria-list li:last-child { border-bottom: none; }
+  .criteria-list li::before { content: "☐"; color: #58a6ff; font-size: 1rem; flex-shrink: 0; line-height: 1.4; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+  p.prose { color: #8b949e; font-size: 0.9rem; line-height: 1.6; margin-top: 8px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / load-data.sh</span>
+</header>
+
+<main>
+  <h2>load-data.sh</h2>
+  <span class="badge">#112 — Add load-model and load-data services to docker-compose.yml</span>
+  <p class="subtitle">Container entrypoint for the <code>load-data</code> compose service. Probes Triton and Qdrant health before running pipeline scripts 03–05 in sequence. Skips script 05 with a warning if <code>TMDB_API_KEY</code> is unset.</p>
+
+  <h3>Overview</h3>
+  <p class="prose">
+    <code>load-data.sh</code> is the container entrypoint for the <code>load-data</code> compose service. Before running any scripts, it probes Triton (<code>http://triton:8000/v2/health/ready</code>) and Qdrant (<code>http://qdrant:6333/healthz</code>) with <code>curl -sf</code>. If either probe fails, it prints one error message listing all unreachable services and exits 1. If both are reachable it runs scripts 03 (<code>03_embed_corpus.py</code>), 04 (<code>04_ingest_qdrant.py</code>), and 05 (<code>05_enrich_tmdb.py</code>) in sequence. Script 05 is skipped with a warning if <code>TMDB_API_KEY</code> is unset or empty. If any script exits non-zero, the entrypoint prints which script failed and its exit code, then stops immediately.
+  </p>
+
+  <h3>Data Contract</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Property</th><th>Type</th><th>Description</th><th>Behavior</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>TMDB_API_KEY</td>
+        <td>env var, string</td>
+        <td>TMDB v3 API key for poster enrichment</td>
+        <td>If unset or empty, script 05 is skipped with a warning; not an error</td>
+      </tr>
+      <tr>
+        <td>Exit code</td>
+        <td>integer</td>
+        <td>Exit code of the entrypoint</td>
+        <td>0 on full success (or TMDB skip); 1 if services unreachable; N (failing script's code) if a script fails</td>
+      </tr>
+      <tr>
+        <td>stdout/stderr</td>
+        <td>string</td>
+        <td>Progress, warnings, and error messages</td>
+        <td>See message formats below</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Message Formats</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Event</th><th>Message</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Triton unreachable (alone)</td>
+        <td><code>"ERROR: the following services are not reachable: triton"</code></td>
+      </tr>
+      <tr>
+        <td>Qdrant unreachable (alone)</td>
+        <td><code>"ERROR: the following services are not reachable: qdrant"</code></td>
+      </tr>
+      <tr>
+        <td>Both unreachable</td>
+        <td><code>"ERROR: the following services are not reachable: triton, qdrant"</code></td>
+      </tr>
+      <tr>
+        <td>TMDB_API_KEY unset/empty</td>
+        <td><code>"WARNING: TMDB_API_KEY is not set — skipping 05_enrich_tmdb.py"</code></td>
+      </tr>
+      <tr>
+        <td>Script N fails</td>
+        <td><code>"ERROR: 03_embed_corpus.py failed with exit code N"</code> (etc.)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Observable Output Examples</h4>
+  <div class="code-block">WARNING: TMDB_API_KEY is not set — skipping 05_enrich_tmdb.py</div>
+  <div class="code-block" style="margin-top:12px;">ERROR: the following services are not reachable: triton, qdrant</div>
+  <div class="code-block" style="margin-top:12px;">ERROR: 03_embed_corpus.py failed with exit code 1</div>
+
+  <h3>Dependencies</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Dependency</th><th>Interface / Type</th><th>Injected As</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Triton health endpoint</td>
+        <td><code>GET http://triton:8000/v2/health/ready</code> → HTTP 200</td>
+        <td>Probed via <code>curl -sf</code></td>
+      </tr>
+      <tr>
+        <td>Qdrant health endpoint</td>
+        <td><code>GET http://qdrant:6333/healthz</code> → HTTP 200</td>
+        <td>Probed via <code>curl -sf</code></td>
+      </tr>
+      <tr>
+        <td>03_embed_corpus.py</td>
+        <td>Python script at <code>/app/03_embed_corpus.py</code></td>
+        <td>Invoked as <code>python3 03_embed_corpus.py --triton-host triton --triton-port 8001</code></td>
+      </tr>
+      <tr>
+        <td>04_ingest_qdrant.py</td>
+        <td>Python script at <code>/app/04_ingest_qdrant.py</code></td>
+        <td>Invoked as <code>python3 04_ingest_qdrant.py --qdrant-url http://qdrant:6333</code></td>
+      </tr>
+      <tr>
+        <td>05_enrich_tmdb.py</td>
+        <td>Python script at <code>/app/05_enrich_tmdb.py</code></td>
+        <td>Invoked as <code>python3 05_enrich_tmdb.py --qdrant-url http://qdrant:6333</code> (only when <code>TMDB_API_KEY</code> is set)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Triton Health Endpoint — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Mock Setup</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Reachable</td><td><code>curl -sf</code> exits 0</td><td>Normal operation</td></tr>
+      <tr><td>Unreachable</td><td><code>curl -sf</code> exits non-zero</td><td>Network down or service not started</td></tr>
+    </tbody>
+  </table>
+
+  <h4>Qdrant Health Endpoint — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Mock Setup</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Reachable</td><td><code>curl -sf</code> exits 0</td><td>Normal operation</td></tr>
+      <tr><td>Unreachable</td><td><code>curl -sf</code> exits non-zero</td><td>Network down or service not started</td></tr>
+    </tbody>
+  </table>
+
+  <h4>03_embed_corpus.py — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Mock Setup</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Happy path</td><td>Script exits 0</td><td>Embeddings written to data/embeddings/</td></tr>
+      <tr><td>Script fails</td><td>Script exits N</td><td>Entrypoint prints error and exits N; scripts 04 and 05 are not run</td></tr>
+    </tbody>
+  </table>
+
+  <h4>04_ingest_qdrant.py — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Mock Setup</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Happy path</td><td>Script exits 0</td><td>Points ingested into Qdrant</td></tr>
+      <tr><td>Script fails</td><td>Script exits N</td><td>Entrypoint prints error and exits N; script 05 is not run</td></tr>
+    </tbody>
+  </table>
+
+  <h4>05_enrich_tmdb.py — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Mock Setup</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Happy path (key set)</td><td><code>TMDB_API_KEY=abc123</code>, script exits 0</td><td>Poster URLs enriched</td></tr>
+      <tr><td>Skipped (key unset)</td><td><code>TMDB_API_KEY</code> not set</td><td>Warning printed; entrypoint exits 0 after scripts 03 and 04</td></tr>
+      <tr><td>Skipped (key empty)</td><td><code>TMDB_API_KEY=""</code></td><td>Same as unset — warning printed, script skipped</td></tr>
+      <tr><td>Script fails</td><td><code>TMDB_API_KEY=abc123</code>, script exits N</td><td>Entrypoint prints error and exits N</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Edge Cases</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>#</th><th>Input</th><th>Expected Output</th><th>Description</th><th>Mock Setup</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Both services reachable, all scripts succeed, TMDB key set</td>
+        <td>Exit code 0; no error or warning lines in stdout</td>
+        <td>Full success</td>
+        <td>All probes and scripts succeed</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Triton unreachable, Qdrant reachable</td>
+        <td>Exit code 1; stdout contains exactly <code>"ERROR: the following services are not reachable: triton"</code>; no scripts run</td>
+        <td>Partial unreachability</td>
+        <td>Triton probe fails</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Both unreachable</td>
+        <td>Exit code 1; stdout contains exactly <code>"ERROR: the following services are not reachable: triton, qdrant"</code>; no scripts run</td>
+        <td>Both services down</td>
+        <td>Both probes fail</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td>Services reachable, <code>TMDB_API_KEY</code> unset</td>
+        <td>Exit code 0; stdout contains <code>"WARNING: TMDB_API_KEY is not set — skipping 05_enrich_tmdb.py"</code>; scripts 03 and 04 run; script 05 not invoked</td>
+        <td>TMDB key missing</td>
+        <td><code>TMDB_API_KEY</code> not in environment</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td>Services reachable, <code>TMDB_API_KEY=""</code></td>
+        <td>Exit code 0; stdout contains <code>"WARNING: TMDB_API_KEY is not set — skipping 05_enrich_tmdb.py"</code>; script 05 not invoked</td>
+        <td>Empty string treated identically to unset</td>
+        <td><code>TMDB_API_KEY</code> set to empty string</td>
+      </tr>
+      <tr>
+        <td>6</td>
+        <td>Script 03 fails with exit code 2</td>
+        <td>Exit code 2; stdout contains <code>"ERROR: 03_embed_corpus.py failed with exit code 2"</code>; scripts 04 and 05 not invoked</td>
+        <td>Fail fast</td>
+        <td>Script 03 exits 2</td>
+      </tr>
+      <tr>
+        <td>7</td>
+        <td>Scripts 03 and 04 succeed, script 05 fails with exit code 1 (key set)</td>
+        <td>Exit code 1; stdout contains <code>"ERROR: 05_enrich_tmdb.py failed with exit code 1"</code></td>
+        <td>Last script failure</td>
+        <td>Scripts 03 and 04 succeed; 05 exits 1</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Unit Test Checklist</h3>
+  <p class="prose">Shell scripts have no Python unit tests. All behavior is verified by the integration test task. The observable contract above defines what integration tests must assert:</p>
+  <ul class="criteria-list" style="margin-top:12px;">
+    <li>Happy path (key set): exit code 0; no error or warning lines in stdout</li>
+    <li>Triton unreachable alone: exit code 1; stdout contains exactly <code>"ERROR: the following services are not reachable: triton"</code>; no scripts run</li>
+    <li>Qdrant unreachable alone: exit code 1; stdout contains exactly <code>"ERROR: the following services are not reachable: qdrant"</code>; no scripts run</li>
+    <li>Both unreachable: exit code 1; stdout contains exactly <code>"ERROR: the following services are not reachable: triton, qdrant"</code>; no scripts run</li>
+    <li><code>TMDB_API_KEY</code> unset: exit code 0; stdout contains <code>"WARNING: TMDB_API_KEY is not set — skipping 05_enrich_tmdb.py"</code>; script 05 not invoked</li>
+    <li><code>TMDB_API_KEY</code> empty string: identical output to unset</li>
+    <li>Script 03 fails with exit code 2: exit code 2; stdout contains <code>"ERROR: 03_embed_corpus.py failed with exit code 2"</code>; scripts 04 and 05 not invoked</li>
+    <li>Script 05 fails with exit code 1 (key set): exit code 1; stdout contains <code>"ERROR: 05_enrich_tmdb.py failed with exit code 1"</code></li>
+    <li>Script 03 invoked with <code>--triton-host triton --triton-port 8001</code></li>
+    <li>Scripts 04 and 05 invoked with <code>--qdrant-url http://qdrant:6333</code></li>
+  </ul>
+
+  <a class="back-link" href="index.html">← Back to Architecture Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+</body>
+</html>

--- a/docs/load-model-sh.html
+++ b/docs/load-model-sh.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — load-model.sh</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  h4 { font-size: 0.9rem; font-weight: 600; margin: 16px 0 6px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.78rem; font-weight: 600; background: #1f3d2e; color: #3fb950; border: 1px solid #2ea043; margin-bottom: 20px; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .code-block { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px 20px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.82rem; color: #e6edf3; overflow-x: auto; line-height: 1.6; margin-top: 8px; white-space: pre-wrap; word-break: break-all; }
+  .criteria-list { list-style: none; padding: 0; margin-top: 8px; }
+  .criteria-list li { display: flex; align-items: flex-start; gap: 10px; padding: 8px 0; border-bottom: 1px solid #21262d; font-size: 0.875rem; color: #c9d1d9; }
+  .criteria-list li:last-child { border-bottom: none; }
+  .criteria-list li::before { content: "☐"; color: #58a6ff; font-size: 1rem; flex-shrink: 0; line-height: 1.4; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+  p.prose { color: #8b949e; font-size: 0.9rem; line-height: 1.6; margin-top: 8px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / load-model.sh</span>
+</header>
+
+<main>
+  <h2>load-model.sh</h2>
+  <span class="badge">#112 — Add load-model and load-data services to docker-compose.yml</span>
+  <p class="subtitle">Container entrypoint for the <code>load-model</code> compose service. Runs pipeline scripts 01–02 in sequence, streams output live, and prints a labelled error with the last 10 lines of output if either script fails.</p>
+
+  <h3>Overview</h3>
+  <p class="prose">
+    <code>load-model.sh</code> is the container entrypoint for the <code>load-model</code> compose service. It runs pipeline scripts 01 (<code>01_download_corpus.py</code>) and 02 (<code>02_export_model.py</code>) in sequence from the <code>/app</code> working directory. Each script's stdout and stderr are streamed live via <code>tee</code> to a temporary file. If a script exits non-zero, the entrypoint prints the last 10 lines of that script's output followed by a clearly-labelled error line, then exits with the same code. On success it exits 0. It has no service dependencies and is intended to run before Triton starts.
+  </p>
+
+  <h4>Why capture output</h4>
+  <p class="prose">Scripts 01 and 02 can fail for distinct, diagnosable reasons:</p>
+  <ul style="color:#8b949e;font-size:0.9rem;line-height:1.8;margin-top:8px;padding-left:20px;">
+    <li>Script 01 (<code>01_download_corpus.py</code>): network error fetching the CMU corpus URL, disk-full or permission error writing to <code>data/raw/</code>, or a corrupt/incomplete tarball during extraction.</li>
+    <li>Script 02 (<code>02_export_model.py</code>): HuggingFace download failure for the tokenizer or model, OOM during ONNX export, ONNX runtime load error, or shape assertion failure on the verification pass.</li>
+  </ul>
+  <p class="prose" style="margin-top:8px;">Python already prints tracebacks to stderr. By replaying the last 10 lines inline, the error summary is self-contained in <code>docker compose logs</code> without needing to scroll up or re-run the container.</p>
+
+  <h3>Data Contract</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Property</th><th>Type</th><th>Description</th><th>Behavior</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Exit code</td>
+        <td>integer</td>
+        <td>Exit code of the entrypoint</td>
+        <td>0 on full success; non-zero (the failing script's exit code) on any script failure</td>
+      </tr>
+      <tr>
+        <td>stdout/stderr</td>
+        <td>string</td>
+        <td>Progress and error messages</td>
+        <td>See message formats below</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Message Formats</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Event</th><th>Message</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Script starts</td>
+        <td><code>"Running 01_download_corpus.py..."</code> (repeated for each script)</td>
+      </tr>
+      <tr>
+        <td>Output replay separator</td>
+        <td><code>"--- last output from 01_download_corpus.py ---"</code> (printed before the error line on failure)</td>
+      </tr>
+      <tr>
+        <td>Script fails</td>
+        <td><code>"ERROR: 01_download_corpus.py failed with exit code N"</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Observable Output Examples</h4>
+  <div class="code-block">Running 01_download_corpus.py...
+Downloading corpus from https://www.cs.cmu.edu/~ark/...
+Traceback (most recent call last):
+  File "01_download_corpus.py", line 27, in download_and_extract
+    with urllib.request.urlopen(url) as response:
+  ...
+urllib.error.URLError: &lt;urlopen error [Errno -2] Name or service not known&gt;
+--- last output from 01_download_corpus.py ---
+ERROR: 01_download_corpus.py failed with exit code 1</div>
+
+  <div class="code-block" style="margin-top:12px;">Running 02_export_model.py...
+...
+Verifying ONNX model...
+Traceback (most recent call last):
+  File "02_export_model.py", line 89, in main
+    assert pooled.shape == (1, 384), f"Unexpected shape: {pooled.shape}"
+AssertionError: Unexpected shape: (1, 256)
+--- last output from 02_export_model.py ---
+ERROR: 02_export_model.py failed with exit code 1</div>
+
+  <h3>Dependencies</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Dependency</th><th>Interface / Type</th><th>Injected As</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>01_download_corpus.py</td>
+        <td>Python script at <code>/app/01_download_corpus.py</code></td>
+        <td>Invoked via <code>python3 01_download_corpus.py</code></td>
+      </tr>
+      <tr>
+        <td>02_export_model.py</td>
+        <td>Python script at <code>/app/02_export_model.py</code></td>
+        <td>Invoked via <code>python3 02_export_model.py</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>01_download_corpus.py — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Mock Setup</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Happy path</td><td>Script exits 0</td><td>Normal download and extraction</td></tr>
+      <tr><td>Already downloaded</td><td>Script exits 0, prints skip message</td><td>Idempotent; entrypoint exits 0</td></tr>
+      <tr><td>Network error</td><td>Script raises <code>urllib.error.URLError</code>, exits 1</td><td>Traceback visible in last-10-lines replay</td></tr>
+      <tr><td>Disk full / permission denied</td><td>Script raises <code>OSError</code>, exits 1</td><td>Traceback visible in replay</td></tr>
+      <tr><td>Corrupt archive</td><td>Script raises <code>tarfile.TarError</code>, exits 1</td><td>Traceback visible in replay</td></tr>
+    </tbody>
+  </table>
+
+  <h4>02_export_model.py — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Mock Setup</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Happy path</td><td>Script exits 0</td><td>Normal ONNX export</td></tr>
+      <tr><td>Already exported</td><td>Script exits 0, prints skip message</td><td>Idempotent; entrypoint exits 0</td></tr>
+      <tr><td>HuggingFace download failure</td><td><code>AutoTokenizer.from_pretrained</code> raises <code>OSError</code>, exits 1</td><td>Traceback names the model and URL</td></tr>
+      <tr><td>OOM during export</td><td><code>torch.onnx.export</code> raises <code>RuntimeError</code>, exits 1</td><td>Traceback names the step</td></tr>
+      <tr><td>Shape assertion failure</td><td><code>assert pooled.shape == (1, 384)</code> fails, exits 1</td><td>Traceback includes actual shape</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Edge Cases</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>#</th><th>Input</th><th>Expected Output</th><th>Description</th><th>Mock Setup</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Both scripts exit 0</td>
+        <td>Exit code 0; stdout ends with <code>"Running 02_export_model.py..."</code> and the script's own output; no error lines</td>
+        <td>Full success</td>
+        <td>Both scripts succeed</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Script 01 exits 1</td>
+        <td>Exit code 1; stdout contains <code>"--- last output from 01_download_corpus.py ---"</code> followed by <code>"ERROR: 01_download_corpus.py failed with exit code 1"</code>; script 02 never started</td>
+        <td>Fail fast on first failure</td>
+        <td>Script 01 exits 1</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Script 01 exits 0, script 02 exits 3</td>
+        <td>Exit code 3; stdout contains <code>"--- last output from 02_export_model.py ---"</code> followed by <code>"ERROR: 02_export_model.py failed with exit code 3"</code></td>
+        <td>Exact exit code propagated</td>
+        <td>Script 02 exits 3</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td>Script 01 raises <code>urllib.error.URLError</code> (exits 1)</td>
+        <td>Exit code 1; stdout contains the <code>urllib.error.URLError</code> traceback, then <code>"--- last output from 01_download_corpus.py ---"</code>, then <code>"ERROR: 01_download_corpus.py failed with exit code 1"</code></td>
+        <td>Network error surfaced inline</td>
+        <td>Script 01 raises network error</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td>Script 02 raises shape <code>AssertionError</code> (exits 1)</td>
+        <td>Exit code 1; stdout contains <code>"AssertionError: Unexpected shape: (1, N)"</code>, then <code>"--- last output from 02_export_model.py ---"</code>, then <code>"ERROR: 02_export_model.py failed with exit code 1"</code></td>
+        <td>Shape error surfaced inline</td>
+        <td>Script 02 fails assertion</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Unit Test Checklist</h3>
+  <p class="prose">Shell scripts have no Python unit tests. All behavior is verified by the integration test task. The observable contract above defines what integration tests must assert:</p>
+  <ul class="criteria-list" style="margin-top:12px;">
+    <li>Happy path: exit code 0; no error lines in stdout</li>
+    <li>Script 01 fails with exit code 1: exit code 1; stdout contains <code>"--- last output from 01_download_corpus.py ---"</code> followed by <code>"ERROR: 01_download_corpus.py failed with exit code 1"</code>; script 02 not invoked</li>
+    <li>Script 02 fails with exit code 3: exit code 3; stdout contains <code>"--- last output from 02_export_model.py ---"</code> followed by <code>"ERROR: 02_export_model.py failed with exit code 3"</code></li>
+    <li>Script output is streamed live (not buffered until completion)</li>
+  </ul>
+
+  <a class="back-link" href="index.html">← Back to Architecture Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
Converts the three feature-112 component specs into styled HTML documentation pages and integrates them into the docs site navigation.

## Changes
- `docs/load-model-sh.html` — new HTML page for the load-model.sh spec (data contract, message formats, dependencies, mock behaviors, edge cases, unit test checklist)
- `docs/load-data-sh.html` — new HTML page for the load-data.sh spec (health probe contract, TMDB skip behavior, message formats, edge cases, unit test checklist)
- `docs/docker-compose-services.html` — new HTML page for the DockerComposeServices spec (operator commands, load-model and load-data service configs, .env.example change, edge cases)
- `docs/index.html` — added Feature #112 section with navigation links to all three new pages

## Verification
All acceptance criteria from #127 verified before opening this PR.

Closes #127