### PR TITLE
Bug: Remove stale 'make pipeline' references from README.md and TritonModelRepository.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,6 @@ open http://localhost:8080
 Or with Make:
 
 ```bash
-make pipeline   # export model, start services, load data
 make up         # start all services
 make down       # stop all services
 ```


### PR DESCRIPTION
## Summary
Removes the stale `make pipeline` line from the README.md Quick Start section so the grep integration check returns no output.

## Changes
- `README.md` — removed `make pipeline   # export model, start services, load data` from the "Or with Make:" block; `make up` and `make down` remain

## Verification
All acceptance criteria from #148 verified before opening this PR: `grep -r 'make pipeline' /repo/README.md /repo/docs/specs/feature-6/TritonModelRepository.html` returns no output.

Closes #148