### PR TITLE
Add load-model.sh and load-data.sh to README repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ movie-semantic-search/
 │
 ├── pipeline/
 │   ├── requirements.txt
+│   ├── load-model.sh               # Entrypoint: export model to ONNX (Docker Compose service)
+│   ├── load-data.sh                # Entrypoint: embed corpus and ingest into Qdrant (Docker Compose service)
 │   ├── 01_download_corpus.py       # Fetch and extract CMU dataset
 │   ├── 02_export_model.py          # Export all-MiniLM-L6-v2 to ONNX
 │   ├── 03_embed_corpus.py          # Batch-embed all plot summaries via Triton


### PR DESCRIPTION
## Summary
Adds `load-model.sh` and `load-data.sh` to the README repository structure section.

## Changes
- `README.md` — added `load-model.sh` and `load-data.sh` entries to the `pipeline/` directory tree in the repository structure overview

## Verification
Fixes the missing `load-model` reference that caused integration check 5 to fail.

Closes #151