### PR TITLE
Bug: fix load-model service to run load-model.sh automatically

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./model-repository:/app/model-repository
+    command: ["/app/load-model.sh"]
 
   load-data:
     profiles: [load-data]

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -12,3 +12,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy pipeline scripts; tests are excluded
 COPY *.py ./
+COPY load-model.sh load-data.sh ./
+RUN chmod +x load-model.sh load-data.sh


### PR DESCRIPTION
## Summary
Fixes the `load-model` Docker Compose service so it automatically runs `/app/load-model.sh` instead of dropping into an interactive Python REPL.

## Changes
- `docker-compose.yml` — added `command: ["/app/load-model.sh"]` to the `load-model` service (mirrors the existing `load-data` service pattern)
- `pipeline/Dockerfile` — added `COPY load-model.sh load-data.sh ./` and `RUN chmod +x load-model.sh load-data.sh` so both shell scripts are present and executable in the image

## Verification
All acceptance criteria from #156 verified before opening this PR.

Closes #156