### PR TITLE
Specs: Pre-flight Docker Compose startup check in integration test suite

### DIFF
--- a/docs/specs/feature-158/ComposePreflight.md
+++ b/docs/specs/feature-158/ComposePreflight.md
@@ -1,0 +1,96 @@
+# ComposePreflight Spec
+
+**Feature:** #158 — Pre-flight Docker Compose startup check in integration test suite
+**Component:** `compose_preflight` (`pipeline/tests/compose_preflight.py`)
+
+## Overview
+
+`compose_preflight` is a standalone module that implements the pre-flight Docker Compose startup check. It exposes a single entry point, `preflight_check(timeout, project_dir)`, that runs `docker compose up -d` and then polls `docker compose ps` until the `triton`, `qdrant`, and `api` service containers all report a `running` state, or the timeout expires. On any failure it raises `PreflightError` with a human-readable message that includes the failing service names or compose exit code and output. The module has no pytest dependency and is independently testable by mocking `subprocess.run`.
+
+## Data Contract
+
+| Property | Type | Description | Behavior |
+|----------|------|-------------|----------|
+| `timeout` | `int` | Maximum seconds to wait for all services to reach running state | Must be > 0; default 60 is applied by the caller (conftest fixture), not here |
+| `project_dir` | `pathlib.Path` or `str` | Absolute path to the directory containing `docker-compose.yml` | Passed as `cwd` to every `subprocess.run` call; must exist |
+| `PreflightError.message` | `str` | Human-readable failure reason | Includes exit code + compose output on `up -d` failure; lists non-running service names on timeout |
+
+## Dependencies
+
+| Dependency | Interface / Type | Injected As |
+|------------|-----------------|-------------|
+| `subprocess.run` | stdlib | Module-level import; mocked in tests |
+| `time.sleep` | stdlib | Module-level import; mocked in tests |
+| `time.monotonic` | stdlib | Module-level import; mocked in tests |
+
+### Dependency Mock Behaviors
+
+#### `subprocess.run` — `docker compose up -d`
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| Happy path | Returns `CompletedProcess(returncode=0, stdout="", stderr="")` | Compose starts successfully |
+| Non-zero exit | Returns `CompletedProcess(returncode=1, stdout="some output", stderr="error detail")` | Compose failed to start |
+
+**Mock data structures:**
+```json
+// Happy path
+{"returncode": 0, "stdout": "", "stderr": ""}
+
+// Failure
+{"returncode": 1, "stdout": "Creating network...\n", "stderr": "Error response from daemon: port is already allocated"}
+```
+
+#### `subprocess.run` — `docker compose ps --format json`
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| All running | Returns JSON list where all three services have `"State": "running"` | Poll succeeds immediately |
+| Partially running | Returns JSON list where ≥1 service has `"State": "starting"` or `"exited"` | Poller must retry |
+| Timeout — still not running | Partial list returned on every call until `time.monotonic()` exceeds deadline | Raises `PreflightError` listing non-running services |
+| Empty output | Returns `CompletedProcess(returncode=0, stdout="[]", stderr="")` | Treated as zero services running; poller retries |
+| `docker compose ps` fails | Returns `CompletedProcess(returncode=1, stdout="", stderr="no such service")` | Raises `PreflightError` with the stderr message |
+
+**Mock data structures:**
+```json
+// All running
+[
+  {"Name": "movie-semantic-search-triton-1", "Service": "triton", "State": "running"},
+  {"Name": "movie-semantic-search-qdrant-1", "Service": "qdrant", "State": "running"},
+  {"Name": "movie-semantic-search-api-1",    "Service": "api",    "State": "running"}
+]
+
+// Partially running (api still starting)
+[
+  {"Name": "movie-semantic-search-triton-1", "Service": "triton", "State": "running"},
+  {"Name": "movie-semantic-search-qdrant-1", "Service": "qdrant", "State": "running"},
+  {"Name": "movie-semantic-search-api-1",    "Service": "api",    "State": "starting"}
+]
+
+// Empty
+[]
+```
+
+## Edge Cases
+
+| # | Input | Expected Output | Description | Mock Setup |
+|---|-------|----------------|-------------|------------|
+| 1 | `docker compose up -d` exits 1 | `PreflightError("docker compose up -d failed (exit 1):\n<stdout+stderr>")` | Compose itself fails to start | `subprocess.run` returns `returncode=1` on first call |
+| 2 | All services running on first poll | Returns normally (no exception) | Happy path completes in one poll cycle | `up -d` → 0; `ps` → all running |
+| 3 | Services reach running on second poll | Returns normally | Realistic slow-start scenario | First `ps` returns partial; second returns all running |
+| 4 | Timeout expires with qdrant not running | `PreflightError("timed out after 60s; services not running: qdrant")` | One service never starts | `ps` always returns qdrant as `"starting"` until deadline |
+| 5 | Timeout expires with triton and api not running | `PreflightError("timed out after 60s; services not running: triton, api")` | Multiple services fail | `ps` always returns triton and api as non-running |
+| 6 | `docker compose ps` returns empty list | Treated as no services running; poller retries | Compose project not yet visible | `ps` returns `[]` once, then all-running |
+| 7 | `docker compose ps` exits non-zero | `PreflightError("docker compose ps failed: <stderr>")` | ps command itself errors | `subprocess.run` returns `returncode=1` on ps call |
+| 8 | `project_dir` does not contain `docker-compose.yml` | `PreflightError` propagated from compose exit 1 | Wrong directory | compose returns non-zero |
+
+## Unit Test Checklist
+
+- [ ] Happy path: `preflight_check(60, project_dir)` completes without raising when `up -d` exits 0 and all services report `running` on first poll
+- [ ] `up -d` non-zero exit: raises `PreflightError` containing the exit code and combined stdout+stderr; `ps` is never called
+- [ ] Partial running then all running: completes normally after two poll cycles; `time.sleep` called at least once
+- [ ] Timeout — one service stuck: raises `PreflightError` whose message contains `"timed out"` and the non-running service name
+- [ ] Timeout — multiple services stuck: `PreflightError` message lists all non-running service names
+- [ ] Empty `ps` output then all running: completes normally (empty treated as not-yet-running, not as an error)
+- [ ] `ps` non-zero exit: raises `PreflightError` containing the stderr from the ps command
+- [ ] `time.sleep` is called between poll attempts (not a busy-wait loop)

--- a/docs/specs/feature-158/ComposePreflightFixture.md
+++ b/docs/specs/feature-158/ComposePreflightFixture.md
@@ -1,0 +1,75 @@
+# ComposePreflightFixture Spec
+
+**Feature:** #158 — Pre-flight Docker Compose startup check in integration test suite
+**Component:** `compose_preflight_fixture` (`pipeline/tests/conftest.py`)
+
+## Overview
+
+`compose_preflight_fixture` is a session-scoped autouse pytest fixture added to `pipeline/tests/conftest.py`. It reads the `COMPOSE_PREFLIGHT` environment variable; if unset or empty, it returns immediately (opt-in design — default off, so parallel `/execute-task` agent runs are unaffected). When `COMPOSE_PREFLIGHT` is set to any non-empty value, the fixture reads `COMPOSE_STARTUP_TIMEOUT` (default `"60"`), resolves the repo root as `Path(__file__).parent.parent.parent`, and calls `preflight_check(timeout, project_dir)` from `compose_preflight`. If `PreflightError` is raised, the fixture calls `pytest.fail(str(e))`, which aborts the entire session before any test case runs.
+
+## Data Contract
+
+| Property | Type | Description | Behavior |
+|----------|------|-------------|----------|
+| `COMPOSE_PREFLIGHT` | env var (`str`) | Opt-in gate | If absent or empty string, fixture returns without action |
+| `COMPOSE_STARTUP_TIMEOUT` | env var (`str`) | Timeout in seconds | Parsed as `int`; defaults to `60` if absent or empty; raises `pytest.fail` if non-integer |
+| `project_dir` | `pathlib.Path` | Repo root (contains `docker-compose.yml`) | Computed as `Path(__file__).parent.parent.parent` — three levels up from `conftest.py` |
+
+## Dependencies
+
+| Dependency | Interface / Type | Injected As |
+|------------|-----------------|-------------|
+| `compose_preflight.preflight_check` | `(timeout: int, project_dir: Path) -> None` | Module-level import |
+| `compose_preflight.PreflightError` | Exception class | Module-level import |
+| `os.environ` | stdlib | Module-level import |
+| `pytest.fail` | pytest stdlib | Module-level import |
+
+### Dependency Mock Behaviors
+
+#### `compose_preflight.preflight_check`
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| Happy path | Does nothing (returns `None`) | All services running; fixture completes without error |
+| Pre-flight failure | Raises `PreflightError("timed out after 60s; services not running: api")` | Fixture must call `pytest.fail` with that message |
+
+#### `os.environ` (via `monkeypatch.setenv` / `monkeypatch.delenv`)
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| `COMPOSE_PREFLIGHT` unset | `monkeypatch.delenv("COMPOSE_PREFLIGHT", raising=False)` | Fixture must return without calling `preflight_check` |
+| `COMPOSE_PREFLIGHT` set to `"1"` | `monkeypatch.setenv("COMPOSE_PREFLIGHT", "1")` | Fixture must call `preflight_check` |
+| `COMPOSE_STARTUP_TIMEOUT` unset | `monkeypatch.delenv("COMPOSE_STARTUP_TIMEOUT", raising=False)` | `timeout=60` must be passed to `preflight_check` |
+| `COMPOSE_STARTUP_TIMEOUT` set to `"30"` | `monkeypatch.setenv("COMPOSE_STARTUP_TIMEOUT", "30")` | `timeout=30` must be passed to `preflight_check` |
+| `COMPOSE_STARTUP_TIMEOUT` set to `"abc"` | `monkeypatch.setenv("COMPOSE_STARTUP_TIMEOUT", "abc")` | Fixture calls `pytest.fail` with a message indicating invalid timeout value |
+
+**Mock data structures:**
+```python
+# Happy path env
+{"COMPOSE_PREFLIGHT": "1", "COMPOSE_STARTUP_TIMEOUT": "60"}
+
+# Disabled (default)
+{}  # neither env var set
+```
+
+## Edge Cases
+
+| # | Input | Expected Output | Description | Mock Setup |
+|---|-------|----------------|-------------|------------|
+| 1 | `COMPOSE_PREFLIGHT` unset | Fixture returns; `preflight_check` not called | Default-off behavior; no docker interaction | `delenv("COMPOSE_PREFLIGHT")` |
+| 2 | `COMPOSE_PREFLIGHT=""` (empty string) | Fixture returns; `preflight_check` not called | Empty string treated as unset | `setenv("COMPOSE_PREFLIGHT", "")` |
+| 3 | `COMPOSE_PREFLIGHT="1"`, preflight succeeds | Fixture returns normally; no `pytest.fail` | Happy path | `preflight_check` returns `None` |
+| 4 | `COMPOSE_PREFLIGHT="1"`, `PreflightError` raised | `pytest.fail(error_message)` called with exact error message | Pre-flight failure aborts session | `preflight_check` raises `PreflightError("...")` |
+| 5 | `COMPOSE_STARTUP_TIMEOUT` unset | `preflight_check` called with `timeout=60` | Default timeout applied | `delenv("COMPOSE_STARTUP_TIMEOUT")` |
+| 6 | `COMPOSE_STARTUP_TIMEOUT="30"` | `preflight_check` called with `timeout=30` | Custom timeout respected | `setenv("COMPOSE_STARTUP_TIMEOUT", "30")` |
+| 7 | `COMPOSE_STARTUP_TIMEOUT="abc"` | `pytest.fail("COMPOSE_STARTUP_TIMEOUT must be an integer, got: abc")` | Non-integer value caught early | `setenv("COMPOSE_STARTUP_TIMEOUT", "abc")` |
+
+## Unit Test Checklist
+
+- [ ] `COMPOSE_PREFLIGHT` unset: `preflight_check` is never called
+- [ ] `COMPOSE_PREFLIGHT=""`: `preflight_check` is never called
+- [ ] `COMPOSE_PREFLIGHT="1"`, preflight succeeds: fixture completes; `pytest.fail` not called
+- [ ] `COMPOSE_PREFLIGHT="1"`, `PreflightError` raised: `pytest.fail` called with the exact `PreflightError` message
+- [ ] `COMPOSE_STARTUP_TIMEOUT` unset: `preflight_check` called with `timeout=60`
+- [ ] `COMPOSE_STARTUP_TIMEOUT="30"`: `preflight_check` called with `timeout=30`
+- [ ] `COMPOSE_STARTUP_TIMEOUT="abc"`: `pytest.fail` called with a message containing `"COMPOSE_STARTUP_TIMEOUT"` and `"abc"`


### PR DESCRIPTION
## Summary
Add component specs for feature #158 — Pre-flight Docker Compose startup check in integration test suite.

## Changes
- `docs/specs/feature-158/ComposePreflight.md` — spec for `compose_preflight` module (`preflight_check` function + `PreflightError`)
- `docs/specs/feature-158/ComposePreflightFixture.md` — spec for the session-scoped autouse fixture in `conftest.py`

## Notes
Specs are non-functional documentation. Auto-merging without review cycle.