### PR TITLE
Add compose_preflight.py module with preflight_check and unit tests

### DIFF
--- a/pipeline/tests/compose_preflight.py
+++ b/pipeline/tests/compose_preflight.py
@@ -1,0 +1,48 @@
+import subprocess
+import time
+from pathlib import Path
+
+REQUIRED_SERVICES = {"triton", "qdrant", "api"}
+
+
+class PreflightError(Exception):
+    pass
+
+
+def preflight_check(timeout: int, project_dir: Path) -> None:
+    result = subprocess.run(
+        ["docker", "compose", "up", "-d"],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise PreflightError(
+            f"docker compose up -d failed (exit {result.returncode}):\n{result.stdout}{result.stderr}"
+        )
+
+    deadline = time.monotonic() + timeout
+    while True:
+        ps_result = subprocess.run(
+            ["docker", "compose", "ps", "--format", "json"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+        )
+        if ps_result.returncode != 0:
+            raise PreflightError(f"docker compose ps failed: {ps_result.stderr}")
+
+        import json
+        services = json.loads(ps_result.stdout) if ps_result.stdout.strip() else []
+        running = {s["Service"] for s in services if s.get("State") == "running"}
+        not_running = REQUIRED_SERVICES - running
+
+        if not not_running:
+            return
+
+        if time.monotonic() >= deadline:
+            raise PreflightError(
+                f"timed out after {timeout}s; services not running: {', '.join(sorted(not_running))}"
+            )
+
+        time.sleep(2)

--- a/pipeline/tests/test_compose_preflight.py
+++ b/pipeline/tests/test_compose_preflight.py
@@ -1,0 +1,160 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from pipeline.tests.compose_preflight import PreflightError, preflight_check
+
+
+def _make_run(returncode=0, stdout="", stderr=""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+def _ps_output(states: dict) -> str:
+    return json.dumps([{"Service": svc, "State": state} for svc, state in states.items()])
+
+
+ALL_RUNNING = _ps_output({"triton": "running", "qdrant": "running", "api": "running"})
+
+
+@patch("pipeline.tests.compose_preflight.time.sleep")
+@patch("pipeline.tests.compose_preflight.time.monotonic")
+@patch("pipeline.tests.compose_preflight.subprocess.run")
+def test_all_running_on_first_poll(mock_run, mock_monotonic, mock_sleep, tmp_path):
+    up_result = _make_run(returncode=0)
+    ps_result = _make_run(returncode=0, stdout=ALL_RUNNING)
+    mock_run.side_effect = [up_result, ps_result]
+    mock_monotonic.return_value = 0.0
+
+    preflight_check(60, tmp_path)
+
+    assert mock_run.call_count == 2
+    mock_sleep.assert_not_called()
+
+
+@patch("pipeline.tests.compose_preflight.time.sleep")
+@patch("pipeline.tests.compose_preflight.time.monotonic")
+@patch("pipeline.tests.compose_preflight.subprocess.run")
+def test_up_failure_raises_preflight_error(mock_run, mock_monotonic, mock_sleep, tmp_path):
+    up_result = _make_run(returncode=1, stdout="some output\n", stderr="error detail\n")
+    mock_run.return_value = up_result
+
+    with pytest.raises(PreflightError) as exc_info:
+        preflight_check(60, tmp_path)
+
+    msg = str(exc_info.value)
+    assert "exit 1" in msg
+    assert "some output" in msg
+    assert "error detail" in msg
+    assert mock_run.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+@patch("pipeline.tests.compose_preflight.time.sleep")
+@patch("pipeline.tests.compose_preflight.time.monotonic")
+@patch("pipeline.tests.compose_preflight.subprocess.run")
+def test_running_on_second_poll(mock_run, mock_monotonic, mock_sleep, tmp_path):
+    not_yet = _ps_output({"triton": "starting", "qdrant": "running", "api": "running"})
+    up_result = _make_run(returncode=0)
+    ps_not_yet = _make_run(returncode=0, stdout=not_yet)
+    ps_ready = _make_run(returncode=0, stdout=ALL_RUNNING)
+    mock_run.side_effect = [up_result, ps_not_yet, ps_ready]
+    mock_monotonic.side_effect = [0.0, 1.0, 3.0]
+
+    preflight_check(60, tmp_path)
+
+    assert mock_run.call_count == 3
+    mock_sleep.assert_called_once_with(2)
+
+
+@patch("pipeline.tests.compose_preflight.time.sleep")
+@patch("pipeline.tests.compose_preflight.time.monotonic")
+@patch("pipeline.tests.compose_preflight.subprocess.run")
+def test_timeout_with_one_service_stuck(mock_run, mock_monotonic, mock_sleep, tmp_path):
+    stuck = _ps_output({"triton": "starting", "qdrant": "running", "api": "running"})
+    up_result = _make_run(returncode=0)
+    ps_stuck = _make_run(returncode=0, stdout=stuck)
+    mock_run.side_effect = [up_result, ps_stuck]
+    # deadline = 0.0 + 10 = 10.0; first monotonic for deadline, second exceeds it
+    mock_monotonic.side_effect = [0.0, 11.0]
+
+    with pytest.raises(PreflightError) as exc_info:
+        preflight_check(10, tmp_path)
+
+    msg = str(exc_info.value)
+    assert "timed out" in msg
+    assert "triton" in msg
+
+
+@patch("pipeline.tests.compose_preflight.time.sleep")
+@patch("pipeline.tests.compose_preflight.time.monotonic")
+@patch("pipeline.tests.compose_preflight.subprocess.run")
+def test_timeout_with_multiple_services_stuck(mock_run, mock_monotonic, mock_sleep, tmp_path):
+    stuck = _ps_output({"triton": "starting", "qdrant": "starting", "api": "running"})
+    up_result = _make_run(returncode=0)
+    ps_stuck = _make_run(returncode=0, stdout=stuck)
+    mock_run.side_effect = [up_result, ps_stuck]
+    mock_monotonic.side_effect = [0.0, 11.0]
+
+    with pytest.raises(PreflightError) as exc_info:
+        preflight_check(10, tmp_path)
+
+    msg = str(exc_info.value)
+    assert "timed out" in msg
+    assert "triton" in msg
+    assert "qdrant" in msg
+
+
+@patch("pipeline.tests.compose_preflight.time.sleep")
+@patch("pipeline.tests.compose_preflight.time.monotonic")
+@patch("pipeline.tests.compose_preflight.subprocess.run")
+def test_empty_ps_output_treated_as_not_running(mock_run, mock_monotonic, mock_sleep, tmp_path):
+    up_result = _make_run(returncode=0)
+    ps_empty = _make_run(returncode=0, stdout="[]")
+    ps_ready = _make_run(returncode=0, stdout=ALL_RUNNING)
+    mock_run.side_effect = [up_result, ps_empty, ps_ready]
+    mock_monotonic.side_effect = [0.0, 1.0, 3.0]
+
+    preflight_check(60, tmp_path)
+
+    assert mock_run.call_count == 3
+    mock_sleep.assert_called_once_with(2)
+
+
+@patch("pipeline.tests.compose_preflight.time.sleep")
+@patch("pipeline.tests.compose_preflight.time.monotonic")
+@patch("pipeline.tests.compose_preflight.subprocess.run")
+def test_ps_failure_raises_preflight_error(mock_run, mock_monotonic, mock_sleep, tmp_path):
+    up_result = _make_run(returncode=0)
+    ps_fail = _make_run(returncode=1, stderr="connection refused\n")
+    mock_run.side_effect = [up_result, ps_fail]
+    mock_monotonic.return_value = 0.0
+
+    with pytest.raises(PreflightError) as exc_info:
+        preflight_check(60, tmp_path)
+
+    msg = str(exc_info.value)
+    assert "docker compose ps failed" in msg
+    assert "connection refused" in msg
+
+
+@patch("pipeline.tests.compose_preflight.time.sleep")
+@patch("pipeline.tests.compose_preflight.time.monotonic")
+@patch("pipeline.tests.compose_preflight.subprocess.run")
+def test_sleep_called_between_polls(mock_run, mock_monotonic, mock_sleep, tmp_path):
+    not_yet = _ps_output({"triton": "starting", "qdrant": "running", "api": "running"})
+    up_result = _make_run(returncode=0)
+    ps_not_yet = _make_run(returncode=0, stdout=not_yet)
+    ps_ready = _make_run(returncode=0, stdout=ALL_RUNNING)
+    mock_run.side_effect = [up_result, ps_not_yet, ps_not_yet, ps_ready]
+    mock_monotonic.side_effect = [0.0, 1.0, 3.0, 5.0]
+
+    preflight_check(60, tmp_path)
+
+    assert mock_sleep.call_count >= 1
+    mock_sleep.assert_called_with(2)


### PR DESCRIPTION
## Summary
Creates the `compose_preflight` module with `PreflightError` exception and `preflight_check(timeout, project_dir)` function that starts Docker Compose services and polls until all three required services (`triton`, `qdrant`, `api`) are running or the timeout expires.

## Changes
- `pipeline/tests/compose_preflight.py` — new module with `PreflightError` and `preflight_check`
- `pipeline/tests/test_compose_preflight.py` — 8 unit tests covering all acceptance criteria

## Verification
All acceptance criteria from #162 verified before opening this PR.

Closes #162