### PR TITLE
Wire compose_preflight_fixture into conftest.py with unit tests

### DIFF
--- a/pipeline/tests/conftest.py
+++ b/pipeline/tests/conftest.py
@@ -6,12 +6,15 @@ qdrant_client) so tests can import pipeline scripts without those deps.
 """
 
 import importlib.util
+import os
 import sys
 import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+from pipeline.tests.compose_preflight import preflight_check, PreflightError
 
 
 def _install_stubs():
@@ -119,3 +122,21 @@ def pipeline_loader():
         return module
 
     return _load
+
+
+@pytest.fixture(scope="session", autouse=True)
+def compose_preflight_fixture():
+    if not os.environ.get("COMPOSE_PREFLIGHT"):
+        return
+
+    raw_timeout = os.environ.get("COMPOSE_STARTUP_TIMEOUT", "60") or "60"
+    try:
+        timeout = int(raw_timeout)
+    except ValueError:
+        pytest.fail(f"COMPOSE_STARTUP_TIMEOUT must be an integer, got: {raw_timeout}")
+
+    project_dir = Path(__file__).parent.parent.parent
+    try:
+        preflight_check(timeout, project_dir)
+    except PreflightError as e:
+        pytest.fail(str(e))

--- a/pipeline/tests/test_compose_preflight_fixture.py
+++ b/pipeline/tests/test_compose_preflight_fixture.py
@@ -1,0 +1,91 @@
+"""Unit tests for the compose_preflight_fixture in conftest.py."""
+
+from unittest.mock import patch
+
+import pytest
+
+from pipeline.tests.conftest import compose_preflight_fixture
+
+_MODULE = "pipeline.tests.conftest"
+
+
+def _call_fixture():
+    """Call the fixture's underlying function directly, bypassing pytest's call guard."""
+    fn = getattr(compose_preflight_fixture, "__wrapped__", None) or \
+         getattr(compose_preflight_fixture, "__pytest_wrapped__", None)
+    if fn is not None and hasattr(fn, "obj"):
+        fn = fn.obj
+    (fn or compose_preflight_fixture)()
+
+
+def test_compose_preflight_unset(monkeypatch):
+    """COMPOSE_PREFLIGHT unset: fixture returns without calling preflight_check."""
+    monkeypatch.delenv("COMPOSE_PREFLIGHT", raising=False)
+    with patch(f"{_MODULE}.preflight_check") as mock_check:
+        _call_fixture()
+    mock_check.assert_not_called()
+
+
+def test_compose_preflight_empty_string(monkeypatch):
+    """COMPOSE_PREFLIGHT empty string: fixture returns without calling preflight_check."""
+    monkeypatch.setenv("COMPOSE_PREFLIGHT", "")
+    with patch(f"{_MODULE}.preflight_check") as mock_check:
+        _call_fixture()
+    mock_check.assert_not_called()
+
+
+def test_compose_preflight_success(monkeypatch):
+    """COMPOSE_PREFLIGHT set, preflight succeeds: pytest.fail is never called."""
+    monkeypatch.setenv("COMPOSE_PREFLIGHT", "1")
+    monkeypatch.delenv("COMPOSE_STARTUP_TIMEOUT", raising=False)
+    with patch(f"{_MODULE}.preflight_check") as mock_check, \
+         patch("pytest.fail") as mock_fail:
+        _call_fixture()
+    mock_check.assert_called_once()
+    mock_fail.assert_not_called()
+
+
+def test_compose_preflight_error_raised(monkeypatch):
+    """COMPOSE_PREFLIGHT set, PreflightError raised: pytest.fail called with error message."""
+    monkeypatch.setenv("COMPOSE_PREFLIGHT", "1")
+    monkeypatch.delenv("COMPOSE_STARTUP_TIMEOUT", raising=False)
+    error_msg = "services not running: triton"
+    from pipeline.tests.compose_preflight import PreflightError
+    with patch(f"{_MODULE}.preflight_check", side_effect=PreflightError(error_msg)), \
+         patch(f"{_MODULE}.pytest.fail", side_effect=Exception("fail called")) as mock_fail:
+        with pytest.raises(Exception, match="fail called"):
+            _call_fixture()
+    mock_fail.assert_called_once_with(error_msg)
+
+
+def test_default_timeout(monkeypatch):
+    """COMPOSE_STARTUP_TIMEOUT unset: preflight_check called with timeout=60."""
+    monkeypatch.setenv("COMPOSE_PREFLIGHT", "1")
+    monkeypatch.delenv("COMPOSE_STARTUP_TIMEOUT", raising=False)
+    with patch(f"{_MODULE}.preflight_check") as mock_check:
+        _call_fixture()
+    args = mock_check.call_args[0]
+    assert args[0] == 60
+
+
+def test_custom_timeout(monkeypatch):
+    """COMPOSE_STARTUP_TIMEOUT=30: preflight_check called with timeout=30."""
+    monkeypatch.setenv("COMPOSE_PREFLIGHT", "1")
+    monkeypatch.setenv("COMPOSE_STARTUP_TIMEOUT", "30")
+    with patch(f"{_MODULE}.preflight_check") as mock_check:
+        _call_fixture()
+    args = mock_check.call_args[0]
+    assert args[0] == 30
+
+
+def test_invalid_timeout(monkeypatch):
+    """COMPOSE_STARTUP_TIMEOUT=abc: pytest.fail called with message containing var name and value."""
+    monkeypatch.setenv("COMPOSE_PREFLIGHT", "1")
+    monkeypatch.setenv("COMPOSE_STARTUP_TIMEOUT", "abc")
+    with patch(f"{_MODULE}.pytest.fail", side_effect=Exception("fail called")) as mock_fail:
+        with pytest.raises(Exception, match="fail called"):
+            _call_fixture()
+    assert mock_fail.called
+    fail_msg = mock_fail.call_args[0][0]
+    assert "COMPOSE_STARTUP_TIMEOUT" in fail_msg
+    assert "abc" in fail_msg


### PR DESCRIPTION
## Summary
Adds a session-scoped autouse `compose_preflight_fixture` to `conftest.py` that runs Docker Compose pre-flight checks when `COMPOSE_PREFLIGHT` is set, along with comprehensive unit tests.

## Changes
- `pipeline/tests/conftest.py` — added `import os`, `from pathlib import Path`, `from pipeline.tests.compose_preflight import preflight_check, PreflightError`, and the `compose_preflight_fixture` session-scoped autouse fixture
- `pipeline/tests/test_compose_preflight_fixture.py` — created with 7 unit tests covering all acceptance criteria (unset/empty env var early return, success path, PreflightError handling, default timeout, custom timeout, invalid timeout)

## Verification
All acceptance criteria from #163 verified before opening this PR.

Closes #163