### PR TITLE
Add GitHub Actions workflow for Docker Compose startup check

### DIFF
--- a/.github/workflows/docker-compose-check.yml
+++ b/.github/workflows/docker-compose-check.yml
@@ -1,0 +1,29 @@
+name: Docker Compose Startup Check
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  STARTUP_TIMEOUT: 60
+
+jobs:
+  startup-check:
+    name: Docker Compose Startup Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start services
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --wait --wait-timeout ${{ env.STARTUP_TIMEOUT }}
+
+      - name: Log service states
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml ps
+
+      - name: Tear down services
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml down


### PR DESCRIPTION
## Summary
Creates `.github/workflows/docker-compose-check.yml` to run a Docker Compose startup check on every PR and push to `main`.

## Changes
- `.github/workflows/docker-compose-check.yml` — new workflow that starts services with a configurable timeout, logs service states, and tears down on every run

## Verification
All acceptance criteria from #169 verified before opening this PR.

Closes #169