### PR TITLE
Bug roundup: numpy missing and Dockerfile fixes — Implements task #182

### DIFF
--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -12,3 +12,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy pipeline scripts; tests are excluded
 COPY *.py ./
+
+CMD []

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,6 +1,7 @@
 transformers==4.39.3
 torch>=2.0.0
 onnxruntime==1.17.3
+numpy<2
 tritonclient[grpc]
 tqdm
 qdrant-client


### PR DESCRIPTION
## Summary
Adds `numpy<2` to pipeline requirements and adds `CMD []` to the Dockerfile to fix three documented bugs: missing numpy import, onnxruntime/NumPy 2.x incompatibility, and unexpected CMD directive in the pipeline image.

## Changes
- `pipeline/requirements.txt` — added `numpy<2` (fixes numpy missing; pins below 2.x for onnxruntime compat)
- `pipeline/Dockerfile` — added `CMD []` to override inherited `CMD ["python3"]` from `python:3.11-slim` base image

## Verification
All acceptance criteria from #182 verified before opening this PR.

Closes #182
Closes #175
Closes #176
Closes #179
Closes #180