### PR TITLE
Bug roundup: add onnxscript dependency and CI pipeline image build

### DIFF
--- a/.github/workflows/docker-compose-check.yml
+++ b/.github/workflows/docker-compose-check.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Build pipeline image and verify load scripts
+        run: |
+          docker compose -f docker-compose.yml build load-model
+          docker compose -f docker-compose.yml run --rm --entrypoint sh load-model -c "test -x /app/load-model.sh && test -x /app/load-data.sh"
+
       - name: Start services
         run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --wait --wait-timeout ${{ env.STARTUP_TIMEOUT }}
 

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,6 +1,8 @@
 transformers==4.39.3
 torch>=2.0.0
+numpy==1.26.4
 onnxruntime==1.17.3
+onnxscript==0.7.0
 tritonclient[grpc]
 tqdm
 qdrant-client


### PR DESCRIPTION
## Summary
Fixes `docker compose run --rm load-model` by adding missing dependencies to `pipeline/requirements.txt`, and extends CI to build the pipeline image and verify load scripts are present and executable.

## Changes
- `pipeline/requirements.txt` — added `numpy==1.26.4` (pins NumPy to 1.x, required by `onnxruntime==1.17.3` which was compiled against the NumPy 1.x ABI), and `onnxscript==0.7.0` (required by `torch>=2.11.0` for ONNX export)
- `.github/workflows/docker-compose-check.yml` — added step to build the pipeline image and verify `/app/load-model.sh` and `/app/load-data.sh` exist and are executable

## Verification
- `docker compose run --rm load-model` runs end-to-end and writes `model.onnx` without error
- 117/118 tests pass; the one failure (`test_no_cmd`) is pre-existing and unrelated to these changes

Closes #189
Closes #188
Closes #187