### PR TITLE
[Bug Roundup #194] Bug roundup: 2 bugs — load-model onnxruntime IR mismatch and docs gap

### DIFF
--- a/docs/executive-guide.html
+++ b/docs/executive-guide.html
@@ -127,6 +127,13 @@
         <li>
           <strong>Export the embedding model.</strong> From the repository root, run the following command. This must complete before starting the services:
           <pre class="code-block">docker compose run --rm load-model</pre>
+          <div class="failure">
+            <span class="step-label">If this doesn't work:</span>
+            If the command exits with an error containing "no such file or directory", a stale cached pipeline image is missing the <code>load-model.sh</code> script. Rebuild the image from scratch and re-run:
+            <pre class="code-block">docker compose build --no-cache load-model
+docker compose run --rm load-model</pre>
+            This forces Docker to rebuild the pipeline image from the current source, picking up the latest <code>load-model.sh</code>.
+          </div>
         </li>
         <li>
           <strong>Start all services.</strong> From the repository root, run the following command and wait approximately 30 seconds for all containers to become healthy:

--- a/pipeline/02_export_model.py
+++ b/pipeline/02_export_model.py
@@ -71,6 +71,7 @@ def main():
             "token_embeddings": {0: "batch", 1: "sequence"},
         },
         opset_version=14,
+        dynamo=False,
     )
 
     print("Saving tokenizer files...", flush=True)

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,7 +1,7 @@
 transformers==4.39.3
 torch>=2.0.0
 numpy==1.26.4
-onnxruntime==1.17.3
+onnxruntime>=1.20
 onnxscript==0.7.0
 tritonclient[grpc]
 tqdm


### PR DESCRIPTION
## Summary
Fixes two load-model bugs: upgrades onnxruntime to resolve the IR v10 mismatch and adds a failure recovery note to the executive guide for stale cached images.

## Merged task PRs
- #195 Fix onnxruntime IR mismatch and add load-model failure recovery docs https://github.com/atefft/movie-semantic-search/pull/195

## Verification
All acceptance criteria from #194 were verified through task PRs. CI runs as part of this PR.

Closes #194
- Closes #193 — Bug: docker compose run --rm load-model fails — onnxruntime IR version mismatch
- Closes #192 — Bug: load-model setup step missing failure recovery for stale image