### PR TITLE
[Bug Roundup #199] Bug roundup: 2 bugs — Triton config and docs slash command

### DIFF
--- a/docs/executive-guide.html
+++ b/docs/executive-guide.html
@@ -160,7 +160,7 @@ docker compose run --rm load-model</pre>
             <span class="step-label">If this doesn't work:</span>
             The record count shows 0 or the collection does not exist. From the repository root, re-run the data loader:
             <pre class="code-block">docker compose run --rm load-data</pre>
-            If the collection still shows 0 records after the loader completes, file a bug using <code>/create-feature-request</code>:
+            If the collection still shows 0 records after the loader completes, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: Qdrant movies collection empty after load-data run
 Steps to reproduce:
   1. Run `docker compose run --rm load-data` from the repository root
@@ -179,7 +179,7 @@ Actual: Points count = 0</pre>
             <span class="step-label">If this doesn't work:</span>
             The vector field is null, empty, or absent. From the repository root, re-run the data loader to regenerate embeddings:
             <pre class="code-block">docker compose run --rm load-data</pre>
-            If vectors remain missing after the loader completes, file a bug using <code>/create-feature-request</code>:
+            If vectors remain missing after the loader completes, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: Qdrant movie records missing vector embeddings
 Steps to reproduce:
   1. Run `docker compose run --rm load-data` from the repository root
@@ -198,7 +198,7 @@ Actual: Vector field is null or absent</pre>
             <span class="step-label">If this doesn't work:</span>
             The status shows Red, Yellow, or "Indexing." Wait 60 seconds and refresh. If the problem persists, restart the Qdrant service from the repository root:
             <pre class="code-block">docker compose restart qdrant</pre>
-            If the collection status never becomes Green, file a bug using <code>/create-feature-request</code>:
+            If the collection status never becomes Green, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: Qdrant movies collection stuck in non-Green status
 Steps to reproduce:
   1. Open http://localhost:6333/dashboard from the repository root
@@ -219,7 +219,7 @@ Actual: Collection status = [observed status]</pre>
             <pre class="code-block">docker compose ps api</pre>
             If the container is not running, start it from the repository root:
             <pre class="code-block">docker compose up -d api</pre>
-            If the API is running but returns errors or empty results, file a bug using <code>/create-feature-request</code>:
+            If the API is running but returns errors or empty results, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: GET /api/search returns error or empty results for "sci-fi space adventure"
 Steps to reproduce:
   1. Open http://localhost:8080/swagger-ui/index.html
@@ -240,7 +240,7 @@ Actual: [observed response code and body]</pre>
             <span class="step-label">If this doesn't work:</span>
             The results consist mostly of unrelated films (comedies, dramas, or documentaries unrelated to space). From the repository root, verify that the vector embeddings were generated correctly by re-running the data loader:
             <pre class="code-block">docker compose run --rm load-data</pre>
-            If results remain irrelevant after re-running the data loader, file a bug using <code>/create-feature-request</code>:
+            If results remain irrelevant after re-running the data loader, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: Search results for "sci-fi space adventure" are not relevant
 Steps to reproduce:
   1. Follow steps 1-4 of the End-to-End Test Walkthrough from the repository root

--- a/model-repository/all-minilm-l6-v2/config.pbtxt
+++ b/model-repository/all-minilm-l6-v2/config.pbtxt
@@ -1,21 +1,6 @@
 name: "all-minilm-l6-v2"
-backend: "python"
-
-input [
-  {
-    name: "TEXT"
-    data_type: TYPE_BYTES
-    dims: [ 1 ]
-  }
-]
-
-output [
-  {
-    name: "sentence_embedding"
-    data_type: TYPE_FP32
-    dims: [ 384 ]
-  }
-]
+backend: "onnxruntime"
+max_batch_size: 64
 
 dynamic_batching {
   preferred_batch_size: [ 8, 16 ]

--- a/pipeline/02_export_model.py
+++ b/pipeline/02_export_model.py
@@ -6,6 +6,7 @@ import sys
 import pathlib
 
 import numpy as np
+import onnx
 import torch
 from transformers import AutoTokenizer, AutoModel
 import onnxruntime
@@ -73,6 +74,13 @@ def main():
         opset_version=14,
         dynamo=False,
     )
+
+    # Triton 24.01 bundles onnxruntime that supports IR version ≤ 9; modern onnx
+    # library writes IR version 10. Clamp to 9 so both pipeline and Triton can load it.
+    model_proto = onnx.load(str(ONNX_PATH))
+    if model_proto.ir_version > 9:
+        model_proto.ir_version = 9
+        onnx.save(model_proto, str(ONNX_PATH))
 
     print("Saving tokenizer files...", flush=True)
     tokenizer.save_pretrained(str(OUTPUT_DIR))

--- a/pipeline/03_embed_corpus.py
+++ b/pipeline/03_embed_corpus.py
@@ -76,9 +76,9 @@ def join_data(metadata_map, summaries_map) -> list[dict]:
 def _infer_batch(grpcclient, client, input_ids, attention_mask, token_type_ids):
     B = input_ids.shape[0]
     inputs = [
-        grpcclient.InferInput("input_ids", [B, MAX_LENGTH], "INT32"),
-        grpcclient.InferInput("attention_mask", [B, MAX_LENGTH], "INT32"),
-        grpcclient.InferInput("token_type_ids", [B, MAX_LENGTH], "INT32"),
+        grpcclient.InferInput("input_ids", [B, MAX_LENGTH], "INT64"),
+        grpcclient.InferInput("attention_mask", [B, MAX_LENGTH], "INT64"),
+        grpcclient.InferInput("token_type_ids", [B, MAX_LENGTH], "INT64"),
     ]
     inputs[0].set_data_from_numpy(input_ids)
     inputs[1].set_data_from_numpy(attention_mask)
@@ -121,9 +121,9 @@ def main():
     _infer_batch(
         grpcclient,
         client,
-        dummy_enc["input_ids"].astype("int32"),
-        dummy_enc["attention_mask"].astype("int32"),
-        dummy_enc.get("token_type_ids", np.zeros_like(dummy_enc["input_ids"])).astype("int32"),
+        dummy_enc["input_ids"].astype("int64"),
+        dummy_enc["attention_mask"].astype("int64"),
+        dummy_enc.get("token_type_ids", np.zeros_like(dummy_enc["input_ids"])).astype("int64"),
     )
 
     all_embeddings = []
@@ -137,9 +137,9 @@ def main():
             max_length=MAX_LENGTH,
             truncation=True,
         )
-        input_ids = enc["input_ids"].astype("int32")
-        attention_mask = enc["attention_mask"].astype("int32")
-        token_type_ids = enc.get("token_type_ids", np.zeros_like(input_ids)).astype("int32")
+        input_ids = enc["input_ids"].astype("int64")
+        attention_mask = enc["attention_mask"].astype("int64")
+        token_type_ids = enc.get("token_type_ids", np.zeros_like(input_ids)).astype("int64")
         all_embeddings.append(_infer_batch(grpcclient, client, input_ids, attention_mask, token_type_ids))
 
     embeddings = np.concatenate(all_embeddings, axis=0).astype("float32")

--- a/pipeline/04_ingest_qdrant.py
+++ b/pipeline/04_ingest_qdrant.py
@@ -2,14 +2,7 @@
 import argparse
 import json
 import numpy as np
-from dataclasses import dataclass
-
-
-@dataclass
-class PointStruct:
-    id: int
-    vector: list
-    payload: dict
+from qdrant_client.http.models import PointStruct
 
 
 def build_points(embeddings: np.ndarray, metadata: list) -> list:

--- a/pipeline/05_enrich_tmdb.py
+++ b/pipeline/05_enrich_tmdb.py
@@ -70,18 +70,15 @@ def main():
     limiter = RateLimiter(max_per_second=40)
 
     # Scroll all points where thumbnail_url is null
-    from qdrant_client.models import Filter, FieldCondition, MatchValue
+    from qdrant_client.models import Filter, IsNullCondition, PayloadField
 
     filter_condition = Filter(
         must=[
-            FieldCondition(
-                key="thumbnail_url",
-                match=MatchValue(value=None)
-            )
+            IsNullCondition(is_null=PayloadField(key="thumbnail_url"))
         ]
     )
 
-    points, _ = client.scroll(
+    points, next_offset = client.scroll(
         collection_name="movies",
         limit=100,
         scroll_filter=filter_condition,
@@ -101,11 +98,15 @@ def main():
                     points=[point.id]
                 )
 
-        # Fetch next batch
-        points, _ = client.scroll(
+        if next_offset is None:
+            break
+
+        # Fetch next batch using offset to avoid re-processing points without posters
+        points, next_offset = client.scroll(
             collection_name="movies",
             limit=100,
             scroll_filter=filter_condition,
+            offset=next_offset,
         )
 
 

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # libgomp1 required by torch CPU wheels on slim images
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libgomp1 \
+    && apt-get install -y --no-install-recommends curl libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .


### PR DESCRIPTION
## Summary
Fixes two production bugs: Triton model config incompatibility that prevented `docker compose up -d` from starting, and incorrect `/create-feature-request` slash command in executive-guide.html that should be `/report-bug`.

## Merged task PRs
- #200 Fix Triton config, pipeline compatibility, and docs slash command https://github.com/atefft/movie-semantic-search/pull/200

## Verification
All acceptance criteria from #199 were verified through task PRs. CI runs as part of this PR.

Closes #199
- Closes #198 — Bug: docker compose up -d and docker compose run --rm load-data fail on fresh setup
- Closes #197 — Bug: executive-guide.html instructs users to use /create-feature-request to file bugs