### PR TITLE
Update docs/executive-guide.html: replace docker-compose steps with script references

### DIFF
--- a/docs/executive-guide.html
+++ b/docs/executive-guide.html
@@ -50,6 +50,7 @@
   <nav class="toc">
     <a href="#overview">System Overview</a>
     <a href="#getting-started">Getting Started</a>
+    <a href="#stopping-services">Stopping Services</a>
     <a href="#operator-tools">Operator Tools</a>
     <a href="#walkthrough">Test Walkthrough</a>
   </nav>
@@ -65,11 +66,18 @@
     <section id="getting-started">
       <h2>Getting Started</h2>
       <ol>
-        <li><strong>Export the embedding model.</strong> From the repository root, run <code>docker compose run --rm load-model</code>. This exports the ONNX model into the Triton model repository and must complete before the services start.</li>
-        <li><strong>Start the services.</strong> Launch the system using Docker Desktop by running <code>docker compose up -d</code>. All components — the database, the search service, and the web interface — start together.</li>
-        <li><strong>Load the movie data.</strong> From the repository root, run <code>docker compose run --rm load-data</code> to load all movie information into the system. This only needs to be done once after the initial setup.</li>
+        <li><strong>Start the services.</strong> From the repository root, run <code>./start-services.sh --rebuild</code>. This exports the model, starts all containers, and loads the movie data in one step — use <code>--rebuild</code> for initial setup or any time you want a clean start.
+          <p class="note">The <code>/uat</code> tool should always use <code>--rebuild</code> to avoid stale containers.</p>
+          <p>For everyday startup (when the data is already loaded), run <code>./start-services.sh</code> without flags — it starts containers faster by skipping the data reload.</p>
+        </li>
         <li><strong>Open the Search Interface.</strong> Use the Search Interface link in the Operator Tools section below to open the movie search page in your browser.</li>
       </ol>
+    </section>
+
+    <section id="stopping-services">
+      <h2>Stopping Services</h2>
+      <p>Run <code>./stop-services.sh</code> from the repository root to stop all running containers while preserving your data volumes — use this for a normal shutdown when you plan to restart later.</p>
+      <p>Run <code>./stop-services.sh --clean</code> to perform a full teardown including volumes — use this before running <code>./start-services.sh --rebuild</code> when you need a completely clean state.</p>
     </section>
 
     <section id="operator-tools">
@@ -125,16 +133,8 @@
           <strong>Install Docker Desktop.</strong> Download and install Docker Desktop from <a href="https://www.docker.com/products/docker-desktop/">https://www.docker.com/products/docker-desktop/</a>. Ensure Docker Desktop is running before continuing.
         </li>
         <li>
-          <strong>Export the embedding model.</strong> From the repository root, run the following command. This must complete before starting the services:
-          <pre class="code-block">docker compose run --rm load-model</pre>
-        </li>
-        <li>
-          <strong>Start all services.</strong> From the repository root, run the following command and wait approximately 30 seconds for all containers to become healthy:
-          <pre class="code-block">docker compose up -d</pre>
-        </li>
-        <li>
-          <strong>Load the movie data.</strong> From the repository root, run the following command. This may take several minutes:
-          <pre class="code-block">docker compose run --rm load-data</pre>
+          <strong>Start all services.</strong> From the repository root, run the following command. This exports the model, starts all containers, and loads the movie data in one step:
+          <pre class="code-block">./start-services.sh --rebuild</pre>
         </li>
         <li>
           <strong>Confirm the system is ready.</strong> Open <a href="http://localhost:6333/dashboard">http://localhost:6333/dashboard</a> in your browser. If you see the Qdrant Dashboard without errors, all services are running and you are ready to begin the walkthrough. If you see a connection error, wait 30 seconds and refresh.
@@ -151,12 +151,12 @@
           The movies collection shows a non-zero record count (typically several thousand records), confirming that the data pipeline loaded movie data into the vector database.
           <div class="failure">
             <span class="step-label">If this doesn't work:</span>
-            The record count shows 0 or the collection does not exist. From the repository root, re-run the data loader:
-            <pre class="code-block">docker compose run --rm load-data</pre>
-            If the collection still shows 0 records after the loader completes, file a bug using <code>/create-feature-request</code>:
-            <pre class="code-block">Title: Qdrant movies collection empty after load-data run
+            The record count shows 0 or the collection does not exist. From the repository root, re-run the full setup:
+            <pre class="code-block">./start-services.sh --rebuild</pre>
+            If the collection still shows 0 records after the setup completes, file a bug using <code>/create-feature-request</code>:
+            <pre class="code-block">Title: Qdrant movies collection empty after start-services run
 Steps to reproduce:
-  1. Run `docker compose run --rm load-data` from the repository root
+  1. Run `./start-services.sh --rebuild` from the repository root
   2. Open http://localhost:6333/dashboard and click "movies"
 Expected: Points count &gt; 0
 Actual: Points count = 0</pre>
@@ -170,12 +170,12 @@ Actual: Points count = 0</pre>
           Each record contains a populated embedding — a long array of floating-point numbers — confirming that text embedding was applied to each movie description during ingestion.
           <div class="failure">
             <span class="step-label">If this doesn't work:</span>
-            The vector field is null, empty, or absent. From the repository root, re-run the data loader to regenerate embeddings:
-            <pre class="code-block">docker compose run --rm load-data</pre>
-            If vectors remain missing after the loader completes, file a bug using <code>/create-feature-request</code>:
+            The vector field is null, empty, or absent. From the repository root, re-run the full setup to regenerate embeddings:
+            <pre class="code-block">./start-services.sh --rebuild</pre>
+            If vectors remain missing after the setup completes, file a bug using <code>/create-feature-request</code>:
             <pre class="code-block">Title: Qdrant movie records missing vector embeddings
 Steps to reproduce:
-  1. Run `docker compose run --rm load-data` from the repository root
+  1. Run `./start-services.sh --rebuild` from the repository root
   2. Open a record in http://localhost:6333/dashboard
 Expected: Vector field populated with float array
 Actual: Vector field is null or absent</pre>
@@ -210,8 +210,8 @@ Actual: Collection status = [observed status]</pre>
             <span class="step-label">If this doesn't work:</span>
             The API returns an error or an empty result set. From the repository root, confirm the API service is running:
             <pre class="code-block">docker compose ps api</pre>
-            If the container is not running, start it from the repository root:
-            <pre class="code-block">docker compose up -d api</pre>
+            If the container is not running, restart it from the repository root:
+            <pre class="code-block">docker compose restart api</pre>
             If the API is running but returns errors or empty results, file a bug using <code>/create-feature-request</code>:
             <pre class="code-block">Title: GET /api/search returns error or empty results for "sci-fi space adventure"
 Steps to reproduce:
@@ -231,9 +231,9 @@ Actual: [observed response code and body]</pre>
           The top results are recognizable science fiction or space-themed films (for example: Star Wars, Interstellar, Gravity, The Martian, or 2001: A Space Odyssey), confirming that semantic similarity search is surfacing movies by meaning rather than exact keyword matching.
           <div class="failure">
             <span class="step-label">If this doesn't work:</span>
-            The results consist mostly of unrelated films (comedies, dramas, or documentaries unrelated to space). From the repository root, verify that the vector embeddings were generated correctly by re-running the data loader:
-            <pre class="code-block">docker compose run --rm load-data</pre>
-            If results remain irrelevant after re-running the data loader, file a bug using <code>/create-feature-request</code>:
+            The results consist mostly of unrelated films (comedies, dramas, or documentaries unrelated to space). From the repository root, verify that the vector embeddings were generated correctly by re-running the full setup:
+            <pre class="code-block">./start-services.sh --rebuild</pre>
+            If results remain irrelevant after re-running the setup, file a bug using <code>/create-feature-request</code>:
             <pre class="code-block">Title: Search results for "sci-fi space adventure" are not relevant
 Steps to reproduce:
   1. Follow steps 1-4 of the End-to-End Test Walkthrough from the repository root


### PR DESCRIPTION
## Summary
Updates `docs/executive-guide.html` to replace the three manual `docker compose` prerequisite commands with references to `./start-services.sh` and `./stop-services.sh`, and adds a new "Stopping Services" section.

## Changes
- `docs/executive-guide.html` — removes three `docker compose` steps from Getting Started and Walkthrough Prerequisites; adds `./start-services.sh --rebuild` as the single setup step with a `/uat` note; adds new "Stopping Services" section describing `./stop-services.sh` and `./stop-services.sh --clean`; adds TOC link for Stopping Services; updates failure-block troubleshooting commands to use `./start-services.sh --rebuild`

## Verification
All acceptance criteria from #218 verified before opening this PR.

Closes #218