### PR TITLE
Implement --rebuild mode in start-services.sh — task #210

### DIFF
--- a/start-services.sh
+++ b/start-services.sh
@@ -15,42 +15,60 @@ for arg in "$@"; do
   esac
 done
 
+if [[ "$REBUILD" == "true" ]]; then
+  echo "WARNING: --rebuild will stop all containers, remove volumes (all loaded data will be lost),"
+  echo "and remove locally-built Docker images. This cannot be undone."
+  read -rp "Type 'yes' to continue: " confirm
+  if [[ "$confirm" != "yes" ]]; then
+    echo "Aborting."
+    exit 1
+  fi
+fi
+
 if [[ ! -f .env ]]; then
   echo "Error: .env file not found. Create it with TMDB_API_KEY=<your-key>" >&2
   exit 1
 fi
 
-if [[ "$REBUILD" == "true" ]]; then
-  echo "--rebuild not yet implemented" >&2
-  exit 1
-fi
-
-docker compose up -d
-
 HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-120}
-deadline=$((SECONDS + HEALTH_TIMEOUT))
 
-while [[ $SECONDS -lt $deadline ]]; do
-  if curl -sf http://localhost:8000/v2/health/ready >/dev/null 2>&1 && \
-     curl -sf http://localhost:6333/healthz        >/dev/null 2>&1 && \
-     curl -sf http://localhost:8080/api/operator/health >/dev/null 2>&1; then
-    break
-  fi
-  sleep 5
-done
+wait_for_healthy() {
+  local deadline=$((SECONDS + HEALTH_TIMEOUT))
+  while [[ $SECONDS -lt $deadline ]]; do
+    if curl -sf http://localhost:8000/v2/health/ready >/dev/null 2>&1 && \
+       curl -sf http://localhost:6333/healthz        >/dev/null 2>&1 && \
+       curl -sf http://localhost:8080/api/operator/health >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 5
+  done
+  for name_url in "triton http://localhost:8000/v2/health/ready" \
+                  "qdrant http://localhost:6333/healthz" \
+                  "api http://localhost:8080/api/operator/health"; do
+    name=${name_url%% *}; url=${name_url#* }
+    curl -sf "$url" >/dev/null 2>&1 || echo "Error: $name did not become healthy within ${HEALTH_TIMEOUT}s" >&2
+  done
+  return 1
+}
 
-if ! curl -sf http://localhost:8000/v2/health/ready >/dev/null 2>&1; then
-  echo "Error: service triton did not become healthy within ${HEALTH_TIMEOUT}s" >&2
-  exit 1
+if [[ "$REBUILD" == "true" ]]; then
+  docker compose down --rmi local -v
+
+  rm -rf data/raw/ data/embeddings/ \
+    model-repository/all-minilm-l6-v2/1/model.onnx \
+    model-repository/all-minilm-l6-v2/1/tokenizer.json \
+    model-repository/all-minilm-l6-v2/1/tokenizer_config.json \
+    model-repository/all-minilm-l6-v2/1/vocab.txt \
+    model-repository/all-minilm-l6-v2/1/special_tokens_map.json
+
+  docker compose run --rm load-model || (echo "[rebuild] load-model phase failed — aborting" && exit 1)
+  docker compose up -d || (echo "[rebuild] services-up phase failed — aborting" && exit 1)
+  docker compose run --rm load-data || (echo "[rebuild] load-data phase failed — aborting" && exit 1)
+else
+  docker compose up -d
 fi
-if ! curl -sf http://localhost:6333/healthz >/dev/null 2>&1; then
-  echo "Error: service qdrant did not become healthy within ${HEALTH_TIMEOUT}s" >&2
-  exit 1
-fi
-if ! curl -sf http://localhost:8080/api/operator/health >/dev/null 2>&1; then
-  echo "Error: service api did not become healthy within ${HEALTH_TIMEOUT}s" >&2
-  exit 1
-fi
+
+wait_for_healthy || exit 1
 
 echo "Services are healthy. Access:"
 echo "  Search UI:   http://localhost:8080"


### PR DESCRIPTION
## Summary
Implements the `--rebuild` mode in `start-services.sh`, replacing the placeholder stub with full confirmation, teardown, file cleanup, and pipeline re-run logic.

## Changes
- `start-services.sh` — replaced `--rebuild` stub with: confirmation prompt (exits 1 on non-"yes"), `docker compose down --rmi local -v`, model/data file cleanup, pipeline phases (load-model → up → load-data), and health polling via extracted `wait_for_healthy` function

## Verification
All acceptance criteria from #210 verified before opening this PR.

Closes #210