### PR TITLE
[Feature #205] Update docs/executive-guide.html to reference start-services.sh and stop-services.sh

### DIFF
--- a/docs/executive-guide.html
+++ b/docs/executive-guide.html
@@ -50,6 +50,7 @@
   <nav class="toc">
     <a href="#overview">System Overview</a>
     <a href="#getting-started">Getting Started</a>
+    <a href="#stopping-services">Stopping Services</a>
     <a href="#operator-tools">Operator Tools</a>
     <a href="#walkthrough">Test Walkthrough</a>
   </nav>
@@ -65,11 +66,18 @@
     <section id="getting-started">
       <h2>Getting Started</h2>
       <ol>
-        <li><strong>Export the embedding model.</strong> From the repository root, run <code>docker compose run --rm load-model</code>. This exports the ONNX model into the Triton model repository and must complete before the services start.</li>
-        <li><strong>Start the services.</strong> Launch the system using Docker Desktop by running <code>docker compose up -d</code>. All components — the database, the search service, and the web interface — start together.</li>
-        <li><strong>Load the movie data.</strong> From the repository root, run <code>docker compose run --rm load-data</code> to load all movie information into the system. This only needs to be done once after the initial setup.</li>
+        <li><strong>Start the services.</strong> From the repository root, run <code>./start-services.sh --rebuild</code>. This exports the model, starts all containers, and loads the movie data in one step — use <code>--rebuild</code> for initial setup or any time you want a clean start.
+          <p class="note">The <code>/uat</code> tool should always use <code>--rebuild</code> to avoid stale containers.</p>
+          <p>For everyday startup (when the data is already loaded), run <code>./start-services.sh</code> without flags — it starts containers faster by skipping the data reload.</p>
+        </li>
         <li><strong>Open the Search Interface.</strong> Use the Search Interface link in the Operator Tools section below to open the movie search page in your browser.</li>
       </ol>
+    </section>
+
+    <section id="stopping-services">
+      <h2>Stopping Services</h2>
+      <p>Run <code>./stop-services.sh</code> from the repository root to stop all running containers while preserving your data volumes — use this for a normal shutdown when you plan to restart later.</p>
+      <p>Run <code>./stop-services.sh --clean</code> to perform a full teardown including volumes — use this before running <code>./start-services.sh --rebuild</code> when you need a completely clean state.</p>
     </section>
 
     <section id="operator-tools">
@@ -125,23 +133,8 @@
           <strong>Install Docker Desktop.</strong> Download and install Docker Desktop from <a href="https://www.docker.com/products/docker-desktop/">https://www.docker.com/products/docker-desktop/</a>. Ensure Docker Desktop is running before continuing.
         </li>
         <li>
-          <strong>Export the embedding model.</strong> From the repository root, run the following command. This must complete before starting the services:
-          <pre class="code-block">docker compose run --rm load-model</pre>
-          <div class="failure">
-            <span class="step-label">If this doesn't work:</span>
-            If the command exits with an error containing "no such file or directory", a stale cached pipeline image is missing the <code>load-model.sh</code> script. Rebuild the image from scratch and re-run:
-            <pre class="code-block">docker compose build --no-cache load-model
-docker compose run --rm load-model</pre>
-            This forces Docker to rebuild the pipeline image from the current source, picking up the latest <code>load-model.sh</code>.
-          </div>
-        </li>
-        <li>
-          <strong>Start all services.</strong> From the repository root, run the following command and wait approximately 30 seconds for all containers to become healthy:
-          <pre class="code-block">docker compose up -d</pre>
-        </li>
-        <li>
-          <strong>Load the movie data.</strong> From the repository root, run the following command. This may take several minutes:
-          <pre class="code-block">docker compose run --rm load-data</pre>
+          <strong>Start all services.</strong> From the repository root, run the following command. This exports the model, starts all containers, and loads the movie data in one step:
+          <pre class="code-block">./start-services.sh --rebuild</pre>
         </li>
         <li>
           <strong>Confirm the system is ready.</strong> Open <a href="http://localhost:6333/dashboard">http://localhost:6333/dashboard</a> in your browser. If you see the Qdrant Dashboard without errors, all services are running and you are ready to begin the walkthrough. If you see a connection error, wait 30 seconds and refresh.
@@ -158,12 +151,12 @@ docker compose run --rm load-model</pre>
           The movies collection shows a non-zero record count (typically several thousand records), confirming that the data pipeline loaded movie data into the vector database.
           <div class="failure">
             <span class="step-label">If this doesn't work:</span>
-            The record count shows 0 or the collection does not exist. From the repository root, re-run the data loader:
-            <pre class="code-block">docker compose run --rm load-data</pre>
-            If the collection still shows 0 records after the loader completes, file a bug using <code>/report-bug</code>:
-            <pre class="code-block">Title: Qdrant movies collection empty after load-data run
+            The record count shows 0 or the collection does not exist. From the repository root, re-run the full setup:
+            <pre class="code-block">./start-services.sh --rebuild</pre>
+            If the collection still shows 0 records after the setup completes, file a bug using <code>/report-bug</code>:
+            <pre class="code-block">Title: Qdrant movies collection empty after start-services run
 Steps to reproduce:
-  1. Run `docker compose run --rm load-data` from the repository root
+  1. Run `./start-services.sh --rebuild` from the repository root
   2. Open http://localhost:6333/dashboard and click "movies"
 Expected: Points count &gt; 0
 Actual: Points count = 0</pre>
@@ -177,12 +170,12 @@ Actual: Points count = 0</pre>
           Each record contains a populated embedding — a long array of floating-point numbers — confirming that text embedding was applied to each movie description during ingestion.
           <div class="failure">
             <span class="step-label">If this doesn't work:</span>
-            The vector field is null, empty, or absent. From the repository root, re-run the data loader to regenerate embeddings:
-            <pre class="code-block">docker compose run --rm load-data</pre>
-            If vectors remain missing after the loader completes, file a bug using <code>/report-bug</code>:
+            The vector field is null, empty, or absent. From the repository root, re-run the full setup to regenerate embeddings:
+            <pre class="code-block">./start-services.sh --rebuild</pre>
+            If vectors remain missing after the setup completes, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: Qdrant movie records missing vector embeddings
 Steps to reproduce:
-  1. Run `docker compose run --rm load-data` from the repository root
+  1. Run `./start-services.sh --rebuild` from the repository root
   2. Open a record in http://localhost:6333/dashboard
 Expected: Vector field populated with float array
 Actual: Vector field is null or absent</pre>
@@ -217,8 +210,8 @@ Actual: Collection status = [observed status]</pre>
             <span class="step-label">If this doesn't work:</span>
             The API returns an error or an empty result set. From the repository root, confirm the API service is running:
             <pre class="code-block">docker compose ps api</pre>
-            If the container is not running, start it from the repository root:
-            <pre class="code-block">docker compose up -d api</pre>
+            If the container is not running, restart it from the repository root:
+            <pre class="code-block">docker compose restart api</pre>
             If the API is running but returns errors or empty results, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: GET /api/search returns error or empty results for "sci-fi space adventure"
 Steps to reproduce:
@@ -238,9 +231,9 @@ Actual: [observed response code and body]</pre>
           The top results are recognizable science fiction or space-themed films (for example: Star Wars, Interstellar, Gravity, The Martian, or 2001: A Space Odyssey), confirming that semantic similarity search is surfacing movies by meaning rather than exact keyword matching.
           <div class="failure">
             <span class="step-label">If this doesn't work:</span>
-            The results consist mostly of unrelated films (comedies, dramas, or documentaries unrelated to space). From the repository root, verify that the vector embeddings were generated correctly by re-running the data loader:
-            <pre class="code-block">docker compose run --rm load-data</pre>
-            If results remain irrelevant after re-running the data loader, file a bug using <code>/report-bug</code>:
+            The results consist mostly of unrelated films (comedies, dramas, or documentaries unrelated to space). From the repository root, verify that the vector embeddings were generated correctly by re-running the full setup:
+            <pre class="code-block">./start-services.sh --rebuild</pre>
+            If results remain irrelevant after re-running the setup, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: Search results for "sci-fi space adventure" are not relevant
 Steps to reproduce:
   1. Follow steps 1-4 of the End-to-End Test Walkthrough from the repository root

--- a/docs/index.html
+++ b/docs/index.html
@@ -139,6 +139,12 @@ flowchart TB
   <div class="nav-links">
     <a href="docker-compose-startup-workflow.html">DockerComposeStartupWorkflow →</a>
   </div>
+
+  <h2 style="margin-top:48px;">Feature #205 — Update Executive Guide for start-services.sh and stop-services.sh</h2>
+  <p class="subtitle">Simplifies the executive guide setup section by replacing manual docker compose commands with the new entry-point scripts.</p>
+  <div class="nav-links">
+    <a href="specs/feature-205/ExecutiveGuideHtml.html">ExecutiveGuideHtml →</a>
+  </div>
 </main>
 
 <footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>

--- a/docs/specs/feature-205/ExecutiveGuideHtml.html
+++ b/docs/specs/feature-205/ExecutiveGuideHtml.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — ExecutiveGuideHtml Spec</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+  p.body-text { color: #8b949e; font-size: 0.9rem; line-height: 1.6; margin-top: 8px; }
+  ul.checklist { color: #8b949e; font-size: 0.875rem; line-height: 1.8; padding-left: 20px; margin-top: 8px; }
+  ul.checklist li { margin-bottom: 4px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="../../index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / ExecutiveGuideHtml Spec</span>
+</header>
+
+<main>
+  <h2>ExecutiveGuideHtml</h2>
+  <p class="subtitle">Spec for <code>docs/executive-guide.html</code> — updated to reference <code>start-services.sh</code> and <code>stop-services.sh</code> (Feature #205).</p>
+
+  <h3>Overview</h3>
+  <p class="body-text">
+    <code>docs/executive-guide.html</code> is the primary human- and agent-facing guide for setting up and operating Movie Semantic Search.
+    The current "Getting Started" section and the "Prerequisites" sub-section of the walkthrough both instruct users to run three separate
+    <code>docker compose</code> commands (<code>load-model</code>, <code>up -d</code>, <code>load-data</code>). With the addition of
+    <code>start-services.sh</code> and <code>stop-services.sh</code> (features #203 and #204), these manual steps must be replaced by
+    references to the new entry-point scripts. The goal is to reduce confusion for both human users and agents (e.g., the <code>/uat</code>
+    tool) by providing a single, predictable startup command.
+  </p>
+
+  <h3>Data Contract</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Property</th><th>Type</th><th>Description</th><th>Behavior</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>start-services.sh --rebuild</td>
+        <td>shell script invocation</td>
+        <td>Full teardown and rebuild from scratch</td>
+        <td>Must be run from repository root; exports model, rebuilds images, loads data</td>
+      </tr>
+      <tr>
+        <td>start-services.sh (no flags)</td>
+        <td>shell script invocation</td>
+        <td>Fast startup using existing images and volumes</td>
+        <td>Skips model export and data load; suitable for everyday restarts</td>
+      </tr>
+      <tr>
+        <td>stop-services.sh</td>
+        <td>shell script invocation</td>
+        <td>Spins down all containers, preserves volumes</td>
+        <td>Fast path — next <code>start-services.sh</code> (no flags) will reuse volumes</td>
+      </tr>
+      <tr>
+        <td>stop-services.sh --clean</td>
+        <td>shell script invocation</td>
+        <td>Full teardown including volumes</td>
+        <td>Use when a completely clean state is required before <code>--rebuild</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Dependencies</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Dependency</th><th>Interface / Type</th><th>Injected As</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>None</td>
+        <td>—</td>
+        <td>This is a static HTML documentation file with no runtime dependencies</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Sections to Change</h3>
+
+  <h3 style="font-size:0.95rem;color:#8b949e;margin-top:20px;">1. "Getting Started" section (<code>id="getting-started"</code>)</h3>
+  <p class="body-text"><strong style="color:#c9d1d9;">Current content:</strong> 4 numbered <code>&lt;li&gt;</code> items — export model, start services, load data, open search interface.</p>
+  <p class="body-text" style="margin-top:8px;"><strong style="color:#c9d1d9;">Required content:</strong></p>
+  <ul class="checklist">
+    <li><code>&lt;li&gt;</code> 1: Run <code>./start-services.sh --rebuild</code> for an initial setup or any time a fresh start is needed (rebuilds images and loads all data). Include a note that the <code>/uat</code> tool should always use <code>--rebuild</code> to avoid stale containers.</li>
+    <li><code>&lt;li&gt;</code> 2 (informational inline note, not a separate step): For everyday startup when services were previously set up, run <code>./start-services.sh</code> (no flags) — uses existing images and volumes without reloading data.</li>
+    <li><code>&lt;li&gt;</code> 3 (formerly step 4): Open the Search Interface (unchanged).</li>
+  </ul>
+  <p class="body-text" style="margin-top:8px;"><strong style="color:#c9d1d9;">Preservation requirement:</strong> All other content — TMDB API key setup, Docker prerequisites, access URLs — must remain unchanged.</p>
+
+  <h3 style="font-size:0.95rem;color:#8b949e;margin-top:20px;">2. "Prerequisites" sub-section inside the walkthrough (<code>id="walkthrough"</code>)</h3>
+  <p class="body-text"><strong style="color:#c9d1d9;">Current content:</strong> 7 numbered <code>&lt;li&gt;</code> items — steps 1–3 are TMDB/env/Docker setup; steps 4–6 are the three docker-compose commands; step 7 is "Confirm the system is ready."</p>
+  <p class="body-text" style="margin-top:8px;"><strong style="color:#c9d1d9;">Required content:</strong> Replace steps 4, 5, and 6 with a single step: run <code>./start-services.sh --rebuild</code> from the repository root (same description as Getting Started step 1). Steps 1–3 and step 7 remain unchanged; step 7 renumbers to step 5.</p>
+
+  <h3 style="font-size:0.95rem;color:#8b949e;margin-top:20px;">3. New "Stopping Services" sub-section</h3>
+  <p class="body-text"><strong style="color:#c9d1d9;">Location:</strong> Add a new <code>&lt;section id="stopping-services"&gt;</code> between the "Getting Started" and "Operator Tools" sections. Also add a corresponding <code>&lt;a href="#stopping-services"&gt;Stopping Services&lt;/a&gt;</code> link to the <code>&lt;nav class="toc"&gt;</code>.</p>
+  <p class="body-text" style="margin-top:8px;"><strong style="color:#c9d1d9;">Required content:</strong></p>
+  <ul class="checklist">
+    <li><code>./stop-services.sh</code> — Stops all containers and preserves volumes for fast restart with <code>./start-services.sh</code>.</li>
+    <li><code>./stop-services.sh --clean</code> — Full teardown including volumes; use before <code>./start-services.sh --rebuild</code> when a completely clean state is required.</li>
+  </ul>
+
+  <h3>Edge Cases</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>#</th><th>Input</th><th>Expected Output</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Agent following the guide with <code>/uat</code></td>
+        <td>Agent runs <code>./start-services.sh --rebuild</code></td>
+        <td>The note must be prominent enough that an agent reading the guide chooses <code>--rebuild</code></td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>User reading guide for everyday startup</td>
+        <td>User understands <code>./start-services.sh</code> (no flags) is the fast path</td>
+        <td>The distinction between <code>--rebuild</code> and no-flag must be clear from the one-line descriptions</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>User wants to wipe and restart</td>
+        <td>User runs <code>./stop-services.sh --clean</code> then <code>./start-services.sh --rebuild</code></td>
+        <td>The "Stopping Services" section must make the <code>--clean</code> + <code>--rebuild</code> pairing explicit</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Unit Test Checklist</h3>
+  <p class="body-text">This is a documentation-only change; there are no unit tests. Acceptance is verified by manual inspection of the rendered HTML:</p>
+  <ul class="checklist">
+    <li>"Getting Started" section contains no references to <code>docker compose run --rm load-model</code>, <code>docker compose up -d</code>, or <code>docker compose run --rm load-data</code></li>
+    <li>"Getting Started" step 1 references <code>./start-services.sh --rebuild</code> with a one-line description</li>
+    <li>"Getting Started" section includes a note that <code>/uat</code> should use <code>--rebuild</code></li>
+    <li>"Getting Started" section mentions <code>./start-services.sh</code> (no flags) for everyday startup</li>
+    <li>The "Prerequisites" sub-section of the walkthrough contains no references to the three old docker-compose commands</li>
+    <li>The walkthrough "Prerequisites" has a single step replacing the old steps 4–6, referencing <code>./start-services.sh --rebuild</code></li>
+    <li>A "Stopping Services" sub-section exists between "Getting Started" and "Operator Tools"</li>
+    <li>"Stopping Services" describes both <code>./stop-services.sh</code> and <code>./stop-services.sh --clean</code> with one-line descriptions</li>
+    <li>TOC nav includes a link to <code>#stopping-services</code></li>
+    <li>All other content (TMDB key setup, Docker install, access URLs, walkthrough steps 1–3 and confirmation step) is unchanged</li>
+  </ul>
+
+  <a class="back-link" href="../../index.html">← Back to Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+</body>
+</html>

--- a/pipeline/tests/test_executive_guide_205.py
+++ b/pipeline/tests/test_executive_guide_205.py
@@ -1,0 +1,54 @@
+import re
+
+HTML_PATH = "docs/executive-guide.html"
+
+
+def read_html():
+    with open(HTML_PATH) as f:
+        return f.read()
+
+
+def test_no_old_docker_commands():
+    html = read_html()
+    assert "docker compose run --rm load-model" not in html
+    assert "docker compose up -d" not in html
+    assert "docker compose run --rm load-data" not in html
+
+
+def test_rebuild_flag_present_twice():
+    html = read_html()
+    assert html.count("start-services.sh --rebuild") >= 2
+
+
+def test_no_flag_startup_mentioned():
+    html = read_html()
+    assert "start-services.sh" in html  # no-flag variant mentioned
+
+
+def test_stop_services_present():
+    html = read_html()
+    assert "stop-services.sh" in html
+    assert "stop-services.sh --clean" in html
+
+
+def test_stopping_services_section():
+    html = read_html()
+    assert 'id="stopping-services"' in html
+
+
+def test_toc_stopping_services_link():
+    html = read_html()
+    assert '#stopping-services' in html
+
+
+def test_uat_note_present():
+    html = read_html()
+    assert "/uat" in html
+
+
+def test_preserved_content():
+    html = read_html()
+    assert "TMDB" in html
+    assert "localhost:6333" in html
+    assert "localhost:8080" in html
+    assert "docker.com" in html or "docker.com/products" in html


### PR DESCRIPTION
## Summary
Delivers Feature #205: updates `docs/executive-guide.html` to reference `start-services.sh` and `stop-services.sh` in place of manual docker compose commands, with integration tests and spec documentation.

## Merged task PRs
- #223 Update docs/executive-guide.html: replace docker-compose steps with script references https://github.com/atefft/movie-semantic-search/pull/223
- #236 Integration tests: verify executive-guide.html references start-services.sh and stop-services.sh https://github.com/atefft/movie-semantic-search/pull/236
- #240 Docs integration: ExecutiveGuideHtml spec page for feature #205 https://github.com/atefft/movie-semantic-search/pull/240

## Verification
All acceptance criteria from #205 were verified through task PRs. CI runs as part of this PR.

Closes #205