### PR TITLE
Fix localhost hardcoding for Triton/Qdrant in Docker Compose

### DIFF
--- a/api/src/main/java/com/moviesearch/service/impl/QdrantServiceManagerImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/QdrantServiceManagerImpl.java
@@ -60,7 +60,7 @@ public class QdrantServiceManagerImpl implements QdrantServiceManager {
     public ServiceStatus getStatus() {
         try {
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(qdrantProperties.getBaseUrl() + "/health"))
+                    .uri(URI.create(qdrantProperties.getBaseUrl() + "/healthz"))
                     .GET()
                     .build();
             HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,11 +1,11 @@
 triton:
-  host: localhost
+  host: ${TRITON_HOST:localhost}
   port: 8001
-  model-name: all-MiniLM-L6-v2
+  model-name: all-minilm-l6-v2
   deadline-ms: 5000
 
 qdrant:
-  base-url: http://localhost:6333
+  base-url: ${QDRANT_BASE_URL:http://localhost:6333}
   mock: false
 
 search:

--- a/api/src/test/java/com/moviesearch/config/TritonPropertiesTest.java
+++ b/api/src/test/java/com/moviesearch/config/TritonPropertiesTest.java
@@ -14,7 +14,7 @@ class TritonPropertiesTest {
 
     @Test
     void defaultModelNameIsAllMiniLML6v2() {
-        assertThat(tritonProperties.getModelName()).isEqualTo("all-MiniLM-L6-v2");
+        assertThat(tritonProperties.getModelName()).isEqualTo("all-minilm-l6-v2");
     }
 
     @Test

--- a/api/src/test/java/com/moviesearch/service/impl/QdrantServiceManagerImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/QdrantServiceManagerImplTest.java
@@ -162,7 +162,7 @@ class QdrantServiceManagerImplTest {
         manager.getStatus();
 
         verify(httpClient).send(
-                org.mockito.ArgumentMatchers.argThat(req -> req.uri().toString().equals("http://localhost:6333/health")),
+                org.mockito.ArgumentMatchers.argThat(req -> req.uri().toString().equals("http://localhost:6333/healthz")),
                 any(HttpResponse.BodyHandler.class));
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
 
   api:
     build: .
+    environment:
+      - TRITON_HOST=triton
+      - QDRANT_BASE_URL=http://qdrant:6333
     ports:
       - "8080:8080"
     depends_on:

--- a/docs/executive-guide.html
+++ b/docs/executive-guide.html
@@ -50,6 +50,7 @@
   <nav class="toc">
     <a href="#overview">System Overview</a>
     <a href="#getting-started">Getting Started</a>
+    <a href="#stopping-services">Stopping Services</a>
     <a href="#operator-tools">Operator Tools</a>
     <a href="#walkthrough">Test Walkthrough</a>
   </nav>
@@ -65,11 +66,18 @@
     <section id="getting-started">
       <h2>Getting Started</h2>
       <ol>
-        <li><strong>Export the embedding model.</strong> From the repository root, run <code>docker compose run --rm load-model</code>. This exports the ONNX model into the Triton model repository and must complete before the services start.</li>
-        <li><strong>Start the services.</strong> Launch the system using Docker Desktop by running <code>docker compose up -d</code>. All components — the database, the search service, and the web interface — start together.</li>
-        <li><strong>Load the movie data.</strong> From the repository root, run <code>docker compose run --rm load-data</code> to load all movie information into the system. This only needs to be done once after the initial setup.</li>
+        <li><strong>Start the services.</strong> From the repository root, run <code>./start-services.sh --rebuild</code>. This exports the model, starts all containers, and loads the movie data in one step — use <code>--rebuild</code> for initial setup or any time you want a clean start.
+          <p class="note">The <code>/uat</code> tool should always use <code>--rebuild</code> to avoid stale containers.</p>
+          <p>For everyday startup (when the data is already loaded), run <code>./start-services.sh</code> without flags — it starts containers faster by skipping the data reload.</p>
+        </li>
         <li><strong>Open the Search Interface.</strong> Use the Search Interface link in the Operator Tools section below to open the movie search page in your browser.</li>
       </ol>
+    </section>
+
+    <section id="stopping-services">
+      <h2>Stopping Services</h2>
+      <p>Run <code>./stop-services.sh</code> from the repository root to stop all running containers while preserving your data volumes — use this for a normal shutdown when you plan to restart later.</p>
+      <p>Run <code>./stop-services.sh --clean</code> to perform a full teardown including volumes — use this before running <code>./start-services.sh --rebuild</code> when you need a completely clean state.</p>
     </section>
 
     <section id="operator-tools">
@@ -125,23 +133,8 @@
           <strong>Install Docker Desktop.</strong> Download and install Docker Desktop from <a href="https://www.docker.com/products/docker-desktop/">https://www.docker.com/products/docker-desktop/</a>. Ensure Docker Desktop is running before continuing.
         </li>
         <li>
-          <strong>Export the embedding model.</strong> From the repository root, run the following command. This must complete before starting the services:
-          <pre class="code-block">docker compose run --rm load-model</pre>
-          <div class="failure">
-            <span class="step-label">If this doesn't work:</span>
-            If the command exits with an error containing "no such file or directory", a stale cached pipeline image is missing the <code>load-model.sh</code> script. Rebuild the image from scratch and re-run:
-            <pre class="code-block">docker compose build --no-cache load-model
-docker compose run --rm load-model</pre>
-            This forces Docker to rebuild the pipeline image from the current source, picking up the latest <code>load-model.sh</code>.
-          </div>
-        </li>
-        <li>
-          <strong>Start all services.</strong> From the repository root, run the following command and wait approximately 30 seconds for all containers to become healthy:
-          <pre class="code-block">docker compose up -d</pre>
-        </li>
-        <li>
-          <strong>Load the movie data.</strong> From the repository root, run the following command. This may take several minutes:
-          <pre class="code-block">docker compose run --rm load-data</pre>
+          <strong>Start all services.</strong> From the repository root, run the following command. This exports the model, starts all containers, and loads the movie data in one step:
+          <pre class="code-block">./start-services.sh --rebuild</pre>
         </li>
         <li>
           <strong>Confirm the system is ready.</strong> Open <a href="http://localhost:6333/dashboard">http://localhost:6333/dashboard</a> in your browser. If you see the Qdrant Dashboard without errors, all services are running and you are ready to begin the walkthrough. If you see a connection error, wait 30 seconds and refresh.
@@ -158,12 +151,12 @@ docker compose run --rm load-model</pre>
           The movies collection shows a non-zero record count (typically several thousand records), confirming that the data pipeline loaded movie data into the vector database.
           <div class="failure">
             <span class="step-label">If this doesn't work:</span>
-            The record count shows 0 or the collection does not exist. From the repository root, re-run the data loader:
-            <pre class="code-block">docker compose run --rm load-data</pre>
-            If the collection still shows 0 records after the loader completes, file a bug using <code>/report-bug</code>:
-            <pre class="code-block">Title: Qdrant movies collection empty after load-data run
+            The record count shows 0 or the collection does not exist. From the repository root, re-run the full setup:
+            <pre class="code-block">./start-services.sh --rebuild</pre>
+            If the collection still shows 0 records after the setup completes, file a bug using <code>/report-bug</code>:
+            <pre class="code-block">Title: Qdrant movies collection empty after start-services run
 Steps to reproduce:
-  1. Run `docker compose run --rm load-data` from the repository root
+  1. Run `./start-services.sh --rebuild` from the repository root
   2. Open http://localhost:6333/dashboard and click "movies"
 Expected: Points count &gt; 0
 Actual: Points count = 0</pre>
@@ -177,12 +170,12 @@ Actual: Points count = 0</pre>
           Each record contains a populated embedding — a long array of floating-point numbers — confirming that text embedding was applied to each movie description during ingestion.
           <div class="failure">
             <span class="step-label">If this doesn't work:</span>
-            The vector field is null, empty, or absent. From the repository root, re-run the data loader to regenerate embeddings:
-            <pre class="code-block">docker compose run --rm load-data</pre>
-            If vectors remain missing after the loader completes, file a bug using <code>/report-bug</code>:
+            The vector field is null, empty, or absent. From the repository root, re-run the full setup to regenerate embeddings:
+            <pre class="code-block">./start-services.sh --rebuild</pre>
+            If vectors remain missing after the setup completes, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: Qdrant movie records missing vector embeddings
 Steps to reproduce:
-  1. Run `docker compose run --rm load-data` from the repository root
+  1. Run `./start-services.sh --rebuild` from the repository root
   2. Open a record in http://localhost:6333/dashboard
 Expected: Vector field populated with float array
 Actual: Vector field is null or absent</pre>
@@ -217,8 +210,8 @@ Actual: Collection status = [observed status]</pre>
             <span class="step-label">If this doesn't work:</span>
             The API returns an error or an empty result set. From the repository root, confirm the API service is running:
             <pre class="code-block">docker compose ps api</pre>
-            If the container is not running, start it from the repository root:
-            <pre class="code-block">docker compose up -d api</pre>
+            If the container is not running, restart it from the repository root:
+            <pre class="code-block">docker compose restart api</pre>
             If the API is running but returns errors or empty results, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: GET /api/search returns error or empty results for "sci-fi space adventure"
 Steps to reproduce:
@@ -238,9 +231,9 @@ Actual: [observed response code and body]</pre>
           The top results are recognizable science fiction or space-themed films (for example: Star Wars, Interstellar, Gravity, The Martian, or 2001: A Space Odyssey), confirming that semantic similarity search is surfacing movies by meaning rather than exact keyword matching.
           <div class="failure">
             <span class="step-label">If this doesn't work:</span>
-            The results consist mostly of unrelated films (comedies, dramas, or documentaries unrelated to space). From the repository root, verify that the vector embeddings were generated correctly by re-running the data loader:
-            <pre class="code-block">docker compose run --rm load-data</pre>
-            If results remain irrelevant after re-running the data loader, file a bug using <code>/report-bug</code>:
+            The results consist mostly of unrelated films (comedies, dramas, or documentaries unrelated to space). From the repository root, verify that the vector embeddings were generated correctly by re-running the full setup:
+            <pre class="code-block">./start-services.sh --rebuild</pre>
+            If results remain irrelevant after re-running the setup, file a bug using <code>/report-bug</code>:
             <pre class="code-block">Title: Search results for "sci-fi space adventure" are not relevant
 Steps to reproduce:
   1. Follow steps 1-4 of the End-to-End Test Walkthrough from the repository root

--- a/docs/index.html
+++ b/docs/index.html
@@ -139,6 +139,12 @@ flowchart TB
   <div class="nav-links">
     <a href="docker-compose-startup-workflow.html">DockerComposeStartupWorkflow →</a>
   </div>
+
+  <h2 style="margin-top:48px;">Feature #204 — Add stop-services.sh</h2>
+  <p class="subtitle">Single entry-point shell script to stop all Docker Compose services, with optional full volume teardown.</p>
+  <div class="nav-links">
+    <a href="stop-services.html">stop-services.sh →</a>
+  </div>
 </main>
 
 <footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -139,6 +139,12 @@ flowchart TB
   <div class="nav-links">
     <a href="docker-compose-startup-workflow.html">DockerComposeStartupWorkflow →</a>
   </div>
+
+  <h2 style="margin-top:48px;">Feature #205 — Update Executive Guide for start-services.sh and stop-services.sh</h2>
+  <p class="subtitle">Simplifies the executive guide setup section by replacing manual docker compose commands with the new entry-point scripts.</p>
+  <div class="nav-links">
+    <a href="specs/feature-205/ExecutiveGuideHtml.html">ExecutiveGuideHtml →</a>
+  </div>
 </main>
 
 <footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -139,6 +139,12 @@ flowchart TB
   <div class="nav-links">
     <a href="docker-compose-startup-workflow.html">DockerComposeStartupWorkflow →</a>
   </div>
+
+  <h2 style="margin-top:48px;">Feature #203 — Add start-services.sh</h2>
+  <p class="subtitle">Single entry-point Bash script for the service lifecycle — fast default path and full-rebuild path.</p>
+  <div class="nav-links">
+    <a href="start-services-sh.html">start-services.sh →</a>
+  </div>
 </main>
 
 <footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>

--- a/docs/specs/feature-203/StartServicesScript.md
+++ b/docs/specs/feature-203/StartServicesScript.md
@@ -1,0 +1,108 @@
+# StartServicesScript Spec
+
+**Feature:** #203 — Add start-services.sh — single entry-point to start all services
+**Component:** `start-services.sh` (`start-services.sh`)
+
+## Overview
+
+`start-services.sh` is a Bash script at the repository root that provides a single entry point for the service lifecycle. It has two modes: a fast default path (`./start-services.sh`) that brings up containers using existing images and volumes, polls until all three services are healthy, and prints access URLs; and a full-rebuild path (`./start-services.sh --rebuild`) that wipes containers, volumes, locally-built images, and model/data files, then runs the complete pipeline from scratch. The script validates that `.env` exists before doing any Docker work, enforces a configurable health-check timeout, and exits non-zero with a clear message on any failure.
+
+## Data Contract
+
+| Property | Type | Description | Behavior |
+|----------|------|-------------|----------|
+| (no flag) | mode | Default fast path | Runs `docker compose up -d` then polls health |
+| `--rebuild` | mode | Full clean rebuild path | Requires confirmation, wipes everything, runs pipeline |
+| unrecognised flag | exit | Any other argument | Prints usage line, exits 1 |
+| `HEALTH_TIMEOUT` | env var (integer, seconds) | Max seconds to wait for all services to become healthy | Default: `120`; must be a positive integer; overridable at invocation time |
+| `.env` | file | Must exist in the working directory | If absent, script exits 1 with a descriptive message before any Docker call |
+
+## Dependencies
+
+| Dependency | Interface / Type | Invoked As |
+|------------|-----------------|-------------|
+| docker compose | CLI sub-command | `docker compose up -d`, `docker compose down --rmi local -v`, `docker compose run --rm load-model`, `docker compose run --rm load-data` |
+| curl | CLI | `curl -sf <url>` for health-endpoint polling |
+| `.env` file | File presence | Checked via `[[ -f .env ]]` before any docker calls |
+
+### Dependency Behavior
+
+#### docker compose up -d (default path)
+
+| Scenario | Behavior | Notes |
+|----------|----------|-------|
+| Success | Exits 0, containers start in background | Normal operation |
+| Failure (e.g. port conflict) | Exits non-zero | Script propagates exit code due to `set -euo pipefail` |
+
+#### Health polling (curl -sf)
+
+| Scenario | Behavior | Notes |
+|----------|----------|-------|
+| Service returns 2xx | Service marked healthy | Loop continues to next service |
+| Service not yet up (connection refused / non-2xx) | Retry after 5 s | Expected during startup |
+| `HEALTH_TIMEOUT` seconds elapsed, service still unhealthy | Script exits 1 with message naming the unhealthy service(s) | Clear error for the operator |
+
+Endpoints polled:
+- triton: `http://localhost:8000/v2/health/ready`
+- qdrant: `http://localhost:6333/healthz`
+- api: `http://localhost:8080/api/operator/health`
+
+#### docker compose down --rmi local -v (--rebuild path)
+
+| Scenario | Behavior | Notes |
+|----------|----------|-------|
+| Success | Exits 0, containers+volumes+local images removed | `--rmi local` removes only locally-built images (api, pipeline), not pulled images |
+| No running containers | Exits 0 (no-op) | Safe to run on a clean machine |
+| Failure | Script propagates exit code | Rebuild aborted |
+
+#### docker compose run --rm load-model / load-data (--rebuild path)
+
+| Scenario | Behavior | Notes |
+|----------|----------|-------|
+| Success | Exits 0 | Phase complete |
+| Non-zero exit | Script exits 1 with phase name in error message | e.g. "load-model phase failed" |
+
+## Edge Cases
+
+| # | Input | Expected Output | Description | Verification |
+|---|-------|----------------|-------------|--------------|
+| 1 | `.env` missing | Exit 1, message: "Error: .env file not found. Create it with TMDB_API_KEY=..." | Guard before any Docker work | `bash start-services.sh; echo $?` in a dir without .env |
+| 2 | Unknown flag `--foo` | Exit 1, usage line printed | Catch-all for unrecognised flags | `bash start-services.sh --foo; echo $?` |
+| 3 | `HEALTH_TIMEOUT=5`, service takes 10 s | Exit 1, message names the unhealthy service | Timeout enforced | Requires a mock or slow service |
+| 4 | `--rebuild` without typing "yes" | Exit 1, aborted | Confirmation guard | `echo "no" \| bash start-services.sh --rebuild` |
+| 5 | `--rebuild` with "yes" confirmation | Proceeds to wipe and rebuild | Happy path for rebuild | `echo "yes" \| bash start-services.sh --rebuild` |
+| 6 | `load-model` phase fails during `--rebuild` | Exit 1, "load-model phase failed" message | Phase failure propagation | Requires compose returning non-zero |
+
+## File cleanup performed by --rebuild
+
+To match `make clean` semantics, `--rebuild` also removes these files before running the pipeline (in addition to docker compose teardown):
+
+```
+data/raw/
+data/embeddings/
+model-repository/all-minilm-l6-v2/1/model.onnx
+model-repository/all-minilm-l6-v2/1/tokenizer.json
+model-repository/all-minilm-l6-v2/1/tokenizer_config.json
+model-repository/all-minilm-l6-v2/1/vocab.txt
+model-repository/all-minilm-l6-v2/1/special_tokens_map.json
+```
+
+## Access URLs printed on success
+
+```
+Services are healthy. Access:
+  Search UI:    http://localhost:8080
+  Qdrant:       http://localhost:6333/dashboard
+  Swagger UI:   http://localhost:8080/swagger-ui/index.html
+```
+
+## Unit Test Checklist
+
+Since this is a shell script, "unit tests" are verified via `bash -n` (syntax check) and targeted invocation with controlled inputs:
+
+- [ ] `bash -n start-services.sh` exits 0 (no syntax errors)
+- [ ] Missing `.env`: exits 1, stderr contains "not found"
+- [ ] Unrecognised flag `--foo`: exits 1, stdout/stderr contains "Usage"
+- [ ] `--rebuild` with input "no": exits 1 (aborted)
+- [ ] `--rebuild` with input "yes": proceeds past confirmation (further docker calls will fail in unit context — acceptable)
+- [ ] `HEALTH_TIMEOUT` is read from environment when set

--- a/docs/specs/feature-204/StopServices.md
+++ b/docs/specs/feature-204/StopServices.md
@@ -1,0 +1,75 @@
+# StopServices Spec
+
+**Feature:** #204 — Add stop-services.sh — single entry-point to stop all services
+**Component:** `stop-services.sh` (`stop-services.sh`)
+
+## Overview
+
+`stop-services.sh` is a root-level shell script that provides a single, consistent entry point for stopping all Docker Compose services. By default it preserves volumes so that a subsequent `./start-services.sh` is fast (no data reload required). With the `--clean` flag it performs a full teardown including named volumes and bind-mount data directories, requiring `./start-services.sh --rebuild` on next startup. The script detects whether the Docker Compose V2 plugin (`docker compose`) or the legacy standalone binary (`docker-compose`) is available, preferring V2, so it runs correctly across development environments.
+
+## Data Contract
+
+| Property | Type | Description | Behavior |
+|----------|------|-------------|----------|
+| `--clean` flag | CLI argument | Requests full teardown including volumes | Optional. Absent → preserve volumes. Present → remove volumes. |
+| Exit code | integer | Script exit status | `0` on success. Non-zero on: docker compose failure, unrecognised flag. |
+| Stdout/stderr | string | Human-readable status messages | Confirmation message on success; warning with volume list on `--clean`; usage line and error messages to stderr on failure. |
+
+## Dependencies
+
+| Dependency | Interface / Type | Injected As |
+|------------|-----------------|-------------|
+| `docker compose` / `docker-compose` | Shell command | Detected at runtime via `docker compose version` / `docker-compose version` |
+
+### Dependency Mock Behaviors
+
+#### `docker compose` / `docker-compose`
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| Happy path (V2 plugin) | `docker compose version` exits 0 | Normal modern Docker installation |
+| Happy path (V1 standalone) | `docker compose version` exits non-zero; `docker-compose version` exits 0 | Legacy environment |
+| Neither available | Both version checks exit non-zero | Script must error with clear message |
+| `docker compose down` succeeds | Command exits 0 | Normal stop |
+| `docker compose down` fails | Command exits non-zero (e.g. exit 1) | Script must print error and exit non-zero |
+| `docker compose down -v` succeeds | Command exits 0 | Normal clean stop |
+| `docker compose down -v` fails | Command exits non-zero | Script must print error and exit non-zero |
+
+**Mock data structures:**
+```bash
+# Happy-path docker compose down output (stdout)
+ Container movie-semantic-search-api-1      Stopped
+ Container movie-semantic-search-qdrant-1   Stopped
+ Container movie-semantic-search-triton-1   Stopped
+ Network movie-semantic-search_default      Removed
+
+# docker compose down -v additional output
+ Volume movie-semantic-search_qdrant_data   Removed
+```
+
+## Edge Cases
+
+| # | Input | Expected Output | Description | Mock Setup |
+|---|-------|----------------|-------------|------------|
+| 1 | No flags | Exit 0; prints "Services stopped. Volumes preserved — run ./start-services.sh to restart quickly." | Default happy path | `docker compose down` exits 0 |
+| 2 | `--clean` | Exit 0; prints "WARNING: Volumes removed (qdrant_data, model-repository, data). Run ./start-services.sh --rebuild to reinitialise." | Clean happy path | `docker compose down -v` exits 0 |
+| 3 | Unrecognised flag (e.g. `--foo`) | Exit 1; prints usage line to stderr: "Usage: stop-services.sh [--clean]" | Unrecognised flag | N/A |
+| 4 | `docker compose down` exits non-zero | Exit 1; prints "Error: docker compose down failed (exit <N>)" to stderr | Down command failure | `docker compose down` exits 1 |
+| 5 | `docker compose down -v` exits non-zero | Exit 1; prints "Error: docker compose down -v failed (exit <N>)" to stderr | Clean down command failure | `docker compose down -v` exits 1 |
+| 6 | Neither `docker compose` nor `docker-compose` available | Exit 1; prints "Error: neither 'docker compose' nor 'docker-compose' is available" to stderr | Missing docker compose | Both version commands exit non-zero |
+| 7 | Called from a subdirectory | Works correctly; docker compose finds docker-compose.yml | `cd "$(dirname "$0")"` ensures repo root is CWD | N/A |
+| 8 | V1 standalone (`docker-compose`) present, V2 absent | Uses `docker-compose down`; exit 0; prints confirmation | Legacy environment fallback | `docker compose version` exits 1; `docker-compose version` exits 0 |
+
+## Unit Test Checklist
+
+Unit tests for this script are implemented as Bash shell tests (using `bats` or plain shell assertions with a mock `docker` binary on `PATH`). The mock overrides `docker` (or `docker-compose`) to simulate success and failure scenarios.
+
+- [ ] Happy path (no flags): `docker compose down` called; exit 0; stdout contains "Volumes preserved" and "./start-services.sh"
+- [ ] Happy path (`--clean`): `docker compose down -v` called; exit 0; stdout contains "WARNING" and all three volume names (qdrant_data, model-repository, data) and "./start-services.sh --rebuild"
+- [ ] Unrecognised flag: exit 1; stderr contains "Usage: stop-services.sh [--clean]"
+- [ ] `docker compose down` fails: exit 1; stderr contains "Error: docker compose down failed"
+- [ ] `docker compose down -v` fails (with `--clean`): exit 1; stderr contains "Error: docker compose down -v failed"
+- [ ] Neither docker compose nor docker-compose available: exit 1; stderr contains "neither 'docker compose' nor 'docker-compose' is available"
+- [ ] V1 fallback: when `docker compose version` fails and `docker-compose version` succeeds, uses `docker-compose` command
+- [ ] Script is executable (`-x` bit set)
+- [ ] Script changes to its own directory (`cd "$(dirname "$0")"`) before running docker compose

--- a/docs/specs/feature-205/ExecutiveGuideHtml.html
+++ b/docs/specs/feature-205/ExecutiveGuideHtml.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — ExecutiveGuideHtml Spec</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+  p.body-text { color: #8b949e; font-size: 0.9rem; line-height: 1.6; margin-top: 8px; }
+  ul.checklist { color: #8b949e; font-size: 0.875rem; line-height: 1.8; padding-left: 20px; margin-top: 8px; }
+  ul.checklist li { margin-bottom: 4px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="../../index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / ExecutiveGuideHtml Spec</span>
+</header>
+
+<main>
+  <h2>ExecutiveGuideHtml</h2>
+  <p class="subtitle">Spec for <code>docs/executive-guide.html</code> — updated to reference <code>start-services.sh</code> and <code>stop-services.sh</code> (Feature #205).</p>
+
+  <h3>Overview</h3>
+  <p class="body-text">
+    <code>docs/executive-guide.html</code> is the primary human- and agent-facing guide for setting up and operating Movie Semantic Search.
+    The current "Getting Started" section and the "Prerequisites" sub-section of the walkthrough both instruct users to run three separate
+    <code>docker compose</code> commands (<code>load-model</code>, <code>up -d</code>, <code>load-data</code>). With the addition of
+    <code>start-services.sh</code> and <code>stop-services.sh</code> (features #203 and #204), these manual steps must be replaced by
+    references to the new entry-point scripts. The goal is to reduce confusion for both human users and agents (e.g., the <code>/uat</code>
+    tool) by providing a single, predictable startup command.
+  </p>
+
+  <h3>Data Contract</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Property</th><th>Type</th><th>Description</th><th>Behavior</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>start-services.sh --rebuild</td>
+        <td>shell script invocation</td>
+        <td>Full teardown and rebuild from scratch</td>
+        <td>Must be run from repository root; exports model, rebuilds images, loads data</td>
+      </tr>
+      <tr>
+        <td>start-services.sh (no flags)</td>
+        <td>shell script invocation</td>
+        <td>Fast startup using existing images and volumes</td>
+        <td>Skips model export and data load; suitable for everyday restarts</td>
+      </tr>
+      <tr>
+        <td>stop-services.sh</td>
+        <td>shell script invocation</td>
+        <td>Spins down all containers, preserves volumes</td>
+        <td>Fast path — next <code>start-services.sh</code> (no flags) will reuse volumes</td>
+      </tr>
+      <tr>
+        <td>stop-services.sh --clean</td>
+        <td>shell script invocation</td>
+        <td>Full teardown including volumes</td>
+        <td>Use when a completely clean state is required before <code>--rebuild</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Dependencies</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Dependency</th><th>Interface / Type</th><th>Injected As</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>None</td>
+        <td>—</td>
+        <td>This is a static HTML documentation file with no runtime dependencies</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Sections to Change</h3>
+
+  <h3 style="font-size:0.95rem;color:#8b949e;margin-top:20px;">1. "Getting Started" section (<code>id="getting-started"</code>)</h3>
+  <p class="body-text"><strong style="color:#c9d1d9;">Current content:</strong> 4 numbered <code>&lt;li&gt;</code> items — export model, start services, load data, open search interface.</p>
+  <p class="body-text" style="margin-top:8px;"><strong style="color:#c9d1d9;">Required content:</strong></p>
+  <ul class="checklist">
+    <li><code>&lt;li&gt;</code> 1: Run <code>./start-services.sh --rebuild</code> for an initial setup or any time a fresh start is needed (rebuilds images and loads all data). Include a note that the <code>/uat</code> tool should always use <code>--rebuild</code> to avoid stale containers.</li>
+    <li><code>&lt;li&gt;</code> 2 (informational inline note, not a separate step): For everyday startup when services were previously set up, run <code>./start-services.sh</code> (no flags) — uses existing images and volumes without reloading data.</li>
+    <li><code>&lt;li&gt;</code> 3 (formerly step 4): Open the Search Interface (unchanged).</li>
+  </ul>
+  <p class="body-text" style="margin-top:8px;"><strong style="color:#c9d1d9;">Preservation requirement:</strong> All other content — TMDB API key setup, Docker prerequisites, access URLs — must remain unchanged.</p>
+
+  <h3 style="font-size:0.95rem;color:#8b949e;margin-top:20px;">2. "Prerequisites" sub-section inside the walkthrough (<code>id="walkthrough"</code>)</h3>
+  <p class="body-text"><strong style="color:#c9d1d9;">Current content:</strong> 7 numbered <code>&lt;li&gt;</code> items — steps 1–3 are TMDB/env/Docker setup; steps 4–6 are the three docker-compose commands; step 7 is "Confirm the system is ready."</p>
+  <p class="body-text" style="margin-top:8px;"><strong style="color:#c9d1d9;">Required content:</strong> Replace steps 4, 5, and 6 with a single step: run <code>./start-services.sh --rebuild</code> from the repository root (same description as Getting Started step 1). Steps 1–3 and step 7 remain unchanged; step 7 renumbers to step 5.</p>
+
+  <h3 style="font-size:0.95rem;color:#8b949e;margin-top:20px;">3. New "Stopping Services" sub-section</h3>
+  <p class="body-text"><strong style="color:#c9d1d9;">Location:</strong> Add a new <code>&lt;section id="stopping-services"&gt;</code> between the "Getting Started" and "Operator Tools" sections. Also add a corresponding <code>&lt;a href="#stopping-services"&gt;Stopping Services&lt;/a&gt;</code> link to the <code>&lt;nav class="toc"&gt;</code>.</p>
+  <p class="body-text" style="margin-top:8px;"><strong style="color:#c9d1d9;">Required content:</strong></p>
+  <ul class="checklist">
+    <li><code>./stop-services.sh</code> — Stops all containers and preserves volumes for fast restart with <code>./start-services.sh</code>.</li>
+    <li><code>./stop-services.sh --clean</code> — Full teardown including volumes; use before <code>./start-services.sh --rebuild</code> when a completely clean state is required.</li>
+  </ul>
+
+  <h3>Edge Cases</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>#</th><th>Input</th><th>Expected Output</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Agent following the guide with <code>/uat</code></td>
+        <td>Agent runs <code>./start-services.sh --rebuild</code></td>
+        <td>The note must be prominent enough that an agent reading the guide chooses <code>--rebuild</code></td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>User reading guide for everyday startup</td>
+        <td>User understands <code>./start-services.sh</code> (no flags) is the fast path</td>
+        <td>The distinction between <code>--rebuild</code> and no-flag must be clear from the one-line descriptions</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>User wants to wipe and restart</td>
+        <td>User runs <code>./stop-services.sh --clean</code> then <code>./start-services.sh --rebuild</code></td>
+        <td>The "Stopping Services" section must make the <code>--clean</code> + <code>--rebuild</code> pairing explicit</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Unit Test Checklist</h3>
+  <p class="body-text">This is a documentation-only change; there are no unit tests. Acceptance is verified by manual inspection of the rendered HTML:</p>
+  <ul class="checklist">
+    <li>"Getting Started" section contains no references to <code>docker compose run --rm load-model</code>, <code>docker compose up -d</code>, or <code>docker compose run --rm load-data</code></li>
+    <li>"Getting Started" step 1 references <code>./start-services.sh --rebuild</code> with a one-line description</li>
+    <li>"Getting Started" section includes a note that <code>/uat</code> should use <code>--rebuild</code></li>
+    <li>"Getting Started" section mentions <code>./start-services.sh</code> (no flags) for everyday startup</li>
+    <li>The "Prerequisites" sub-section of the walkthrough contains no references to the three old docker-compose commands</li>
+    <li>The walkthrough "Prerequisites" has a single step replacing the old steps 4–6, referencing <code>./start-services.sh --rebuild</code></li>
+    <li>A "Stopping Services" sub-section exists between "Getting Started" and "Operator Tools"</li>
+    <li>"Stopping Services" describes both <code>./stop-services.sh</code> and <code>./stop-services.sh --clean</code> with one-line descriptions</li>
+    <li>TOC nav includes a link to <code>#stopping-services</code></li>
+    <li>All other content (TMDB key setup, Docker install, access URLs, walkthrough steps 1–3 and confirmation step) is unchanged</li>
+  </ul>
+
+  <a class="back-link" href="../../index.html">← Back to Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+</body>
+</html>

--- a/docs/specs/feature-205/ExecutiveGuideHtml.md
+++ b/docs/specs/feature-205/ExecutiveGuideHtml.md
@@ -1,0 +1,77 @@
+# ExecutiveGuideHtml Spec
+
+**Feature:** #205 — Update docs/executive-guide.html to reference start-services.sh and stop-services.sh
+**Component:** `ExecutiveGuideHtml` (`docs/executive-guide.html`)
+
+## Overview
+
+`docs/executive-guide.html` is the primary human- and agent-facing guide for setting up and operating Movie Semantic Search. The current "Getting Started" section and the "Prerequisites" sub-section of the walkthrough both instruct users to run three separate `docker compose` commands (`load-model`, `up -d`, `load-data`). With the addition of `start-services.sh` and `stop-services.sh` (features #203 and #204), these manual steps must be replaced by references to the new entry-point scripts. The goal is to reduce confusion for both human users and agents (e.g., the `/uat` tool) by providing a single, predictable startup command.
+
+## Data Contract
+
+| Property | Type | Description | Behavior |
+|----------|------|-------------|----------|
+| `start-services.sh --rebuild` | shell script invocation | Full teardown and rebuild from scratch | Must be run from repository root; exports model, rebuilds images, loads data |
+| `start-services.sh` (no flags) | shell script invocation | Fast startup using existing images and volumes | Skips model export and data load; suitable for everyday restarts |
+| `stop-services.sh` | shell script invocation | Spins down all containers, preserves volumes | Fast path — next `start-services.sh` (no flags) will reuse volumes |
+| `stop-services.sh --clean` | shell script invocation | Full teardown including volumes | Use when a completely clean state is required before `--rebuild` |
+
+## Dependencies
+
+| Dependency | Interface / Type | Injected As |
+|------------|-----------------|-------------|
+| None | — | This is a static HTML documentation file with no runtime dependencies |
+
+### Dependency Mock Behaviors
+
+No runtime dependencies. This component is a static HTML file.
+
+## Sections to Change
+
+### 1. "Getting Started" section (`id="getting-started"`)
+
+**Current content:** 4 numbered `<li>` items — export model, start services, load data, open search interface.
+
+**Required content:**
+- `<li>` 1: Run `./start-services.sh --rebuild` for an initial setup or any time a fresh start is needed (rebuilds images and loads all data). Include a note that the `/uat` tool should always use `--rebuild` to avoid stale containers.
+- `<li>` 2 (informational inline note, not a separate step): For everyday startup when services were previously set up, run `./start-services.sh` (no flags) — uses existing images and volumes without reloading data.
+- `<li>` 3 (formerly step 4): Open the Search Interface (unchanged).
+
+**Preservation requirement:** All other content — TMDB API key setup, Docker prerequisites, access URLs — must remain unchanged.
+
+### 2. "Prerequisites" sub-section inside the walkthrough (`id="walkthrough"`)
+
+**Current content:** 7 numbered `<li>` items — steps 1–3 are TMDB/env/Docker setup; steps 4–6 are the three docker-compose commands; step 7 is "Confirm the system is ready."
+
+**Required content:** Replace steps 4, 5, and 6 with a single step: run `./start-services.sh --rebuild` from the repository root (same description as Getting Started step 1). Steps 1–3 and step 7 remain unchanged; step 7 renumbers to step 5.
+
+### 3. New "Stopping Services" sub-section
+
+**Location:** Add a new `<section id="stopping-services">` between the "Getting Started" and "Operator Tools" sections. Also add a corresponding `<a href="#stopping-services">Stopping Services</a>` link to the `<nav class="toc">`.
+
+**Required content:**
+- `./stop-services.sh` — Stops all containers and preserves volumes for fast restart with `./start-services.sh`.
+- `./stop-services.sh --clean` — Full teardown including volumes; use before `./start-services.sh --rebuild` when a completely clean state is required.
+
+## Edge Cases
+
+| # | Input | Expected Output | Description | Mock Setup |
+|---|-------|----------------|-------------|------------|
+| 1 | Agent following the guide with `/uat` | Agent runs `./start-services.sh --rebuild` | The note must be prominent enough that an agent reading the guide chooses `--rebuild` | N/A — static HTML |
+| 2 | User reading guide for everyday startup | User understands `./start-services.sh` (no flags) is the fast path | The distinction between `--rebuild` and no-flag must be clear from the one-line descriptions | N/A — static HTML |
+| 3 | User wants to wipe and restart | User runs `./stop-services.sh --clean` then `./start-services.sh --rebuild` | The "Stopping Services" section must make the `--clean` + `--rebuild` pairing explicit | N/A — static HTML |
+
+## Unit Test Checklist
+
+This is a documentation-only change; there are no unit tests. Acceptance is verified by manual inspection of the rendered HTML:
+
+- [ ] "Getting Started" section contains no references to `docker compose run --rm load-model`, `docker compose up -d`, or `docker compose run --rm load-data`
+- [ ] "Getting Started" step 1 references `./start-services.sh --rebuild` with a one-line description
+- [ ] "Getting Started" section includes a note that `/uat` should use `--rebuild`
+- [ ] "Getting Started" section mentions `./start-services.sh` (no flags) for everyday startup
+- [ ] The "Prerequisites" sub-section of the walkthrough contains no references to the three old docker-compose commands
+- [ ] The walkthrough "Prerequisites" has a single step replacing the old steps 4–6, referencing `./start-services.sh --rebuild`
+- [ ] A "Stopping Services" sub-section exists between "Getting Started" and "Operator Tools"
+- [ ] "Stopping Services" describes both `./stop-services.sh` and `./stop-services.sh --clean` with one-line descriptions
+- [ ] TOC nav includes a link to `#stopping-services`
+- [ ] All other content (TMDB key setup, Docker install, access URLs, walkthrough steps 1–3 and confirmation step) is unchanged

--- a/docs/start-services-sh.html
+++ b/docs/start-services-sh.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — start-services.sh Spec</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  h4 { font-size: 0.9rem; font-weight: 600; margin: 16px 0 6px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.78rem; font-weight: 600; background: #1f3d2e; color: #3fb950; border: 1px solid #2ea043; margin-bottom: 20px; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  .prop-table tr:hover td { background: #161b22; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .code-block { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px 20px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.82rem; color: #e6edf3; overflow-x: auto; line-height: 1.6; margin-top: 8px; white-space: pre; }
+  .criteria-list { list-style: none; padding: 0; margin-top: 8px; }
+  .criteria-list li { display: flex; align-items: flex-start; gap: 10px; padding: 8px 0; border-bottom: 1px solid #21262d; font-size: 0.875rem; color: #c9d1d9; }
+  .criteria-list li:last-child { border-bottom: none; }
+  .criteria-list li::before { content: "☐"; color: #58a6ff; font-size: 1rem; flex-shrink: 0; line-height: 1.4; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+  p.prose { color: #8b949e; font-size: 0.9rem; line-height: 1.6; margin-top: 8px; }
+  .tag { display: inline-block; padding: 1px 7px; border-radius: 10px; font-size: 0.75rem; font-weight: 600; vertical-align: middle; }
+  .tag.happy { background: #1f3d2e; color: #3fb950; border: 1px solid #2ea043; }
+  .tag.error { background: #3d1f1f; color: #f85149; border: 1px solid #da3633; }
+  .tag.warn { background: #2e2a1f; color: #d29922; border: 1px solid #9e6a03; }
+  .callout { border-left: 3px solid #58a6ff; background: #161b22; border-radius: 4px; padding: 12px 16px; margin: 12px 0; font-size: 0.875rem; color: #c9d1d9; line-height: 1.5; }
+  .callout.warning { border-color: #d29922; }
+  .callout.critical { border-color: #f85149; }
+  .callout strong { color: #e6edf3; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / start-services.sh</span>
+</header>
+
+<main>
+  <h2>start-services.sh</h2>
+  <span class="badge">#203 — Add start-services.sh — single entry-point to start all services</span>
+  <p class="subtitle">Bash script at the repo root providing a single entry point for the service lifecycle — fast default path and full-rebuild path.</p>
+
+  <h3>Overview</h3>
+  <p class="prose">
+    <code>start-services.sh</code> is a Bash script at the repository root that provides a single entry point for the service lifecycle. It has two modes: a fast default path (<code>./start-services.sh</code>) that brings up containers using existing images and volumes, polls until all three services are healthy, and prints access URLs; and a full-rebuild path (<code>./start-services.sh --rebuild</code>) that wipes containers, volumes, locally-built images, and model/data files, then runs the complete pipeline from scratch. The script validates that <code>.env</code> exists before doing any Docker work, enforces a configurable health-check timeout, and exits non-zero with a clear message on any failure.
+  </p>
+
+  <h3>Data Contract</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Property</th><th>Type</th><th>Description</th><th>Behavior</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>(no flag)</td>
+        <td>mode</td>
+        <td>Default fast path</td>
+        <td>Runs <code>docker compose up -d</code> then polls all services healthy, then prints URLs</td>
+      </tr>
+      <tr>
+        <td>--rebuild</td>
+        <td>mode</td>
+        <td>Full clean rebuild path</td>
+        <td>Prints warning, requires "yes" confirmation, wipes everything, runs pipeline</td>
+      </tr>
+      <tr>
+        <td>unrecognised flag</td>
+        <td>exit</td>
+        <td>Any other argument</td>
+        <td>Prints usage line to stderr, exits 1</td>
+      </tr>
+      <tr>
+        <td>HEALTH_TIMEOUT</td>
+        <td>env var (integer, seconds)</td>
+        <td>Max seconds to wait for all services to become healthy</td>
+        <td>Default: <code>120</code>; overridable at invocation: <code>HEALTH_TIMEOUT=60 ./start-services.sh</code></td>
+      </tr>
+      <tr>
+        <td>.env file</td>
+        <td>file presence</td>
+        <td>Must exist in working directory</td>
+        <td>Checked via <code>[[ -f .env ]]</code> before any docker calls; exits 1 with helpful message if absent</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Dependencies</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Dependency</th><th>Interface / Type</th><th>Invoked As</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>docker compose</td>
+        <td>CLI sub-command</td>
+        <td><code>docker compose up -d</code>, <code>docker compose down --rmi local -v</code>, <code>docker compose run --rm load-model</code>, <code>docker compose run --rm load-data</code></td>
+      </tr>
+      <tr>
+        <td>curl</td>
+        <td>CLI</td>
+        <td><code>curl -sf &lt;url&gt;</code> for health-endpoint polling</td>
+      </tr>
+      <tr>
+        <td>.env file</td>
+        <td>file presence</td>
+        <td>Checked via <code>[[ -f .env ]]</code> at start of script</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Health endpoints polled (default path + post-up in rebuild)</h4>
+  <div class="code-block">triton  → http://localhost:8000/v2/health/ready
+qdrant  → http://localhost:6333/healthz
+api     → http://localhost:8080/api/operator/health</div>
+
+  <div class="callout">
+    <strong>Poll interval:</strong> 5 seconds between retries. <code>HEALTH_TIMEOUT</code> (default 120 s) is the total wall-clock budget for all three services to become healthy.
+  </div>
+
+  <h4>docker compose down --rmi local -v (--rebuild only)</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Tag</th><th>Behavior</th><th>Notes</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Success</td>
+        <td><span class="tag happy">happy</span></td>
+        <td>Exits 0, containers + volumes + local images removed</td>
+        <td><code>--rmi local</code> removes only locally-built images (api, pipeline); pulled images like triton/qdrant are preserved</td>
+      </tr>
+      <tr>
+        <td>No running containers</td>
+        <td><span class="tag happy">happy</span></td>
+        <td>Exits 0 (no-op)</td>
+        <td>Safe to run on a clean machine</td>
+      </tr>
+      <tr>
+        <td>Failure</td>
+        <td><span class="tag error">error</span></td>
+        <td>Script propagates exit code</td>
+        <td>Rebuild aborted; <code>set -euo pipefail</code> handles propagation</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout warning">
+    <strong>--rmi local vs --rmi all:</strong> Use <code>--rmi local</code> to avoid re-pulling large pulled images like the Triton server (~10 GB). Only the locally-built api and pipeline images are removed and rebuilt.
+  </div>
+
+  <h4>docker compose run --rm load-model / load-data (--rebuild only)</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Tag</th><th>Behavior</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Success</td>
+        <td><span class="tag happy">happy</span></td>
+        <td>Exits 0; next phase begins</td>
+      </tr>
+      <tr>
+        <td>Non-zero exit</td>
+        <td><span class="tag error">error</span></td>
+        <td>Script exits 1 with phase name in error message, e.g. "load-model phase failed — aborting"</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>File Cleanup in --rebuild</h3>
+  <p class="prose">To match <code>make clean</code> semantics, <code>--rebuild</code> removes these files before running the pipeline (in addition to docker compose teardown):</p>
+  <div class="code-block">rm -rf data/raw/ data/embeddings/ \
+  model-repository/all-minilm-l6-v2/1/model.onnx \
+  model-repository/all-minilm-l6-v2/1/tokenizer.json \
+  model-repository/all-minilm-l6-v2/1/tokenizer_config.json \
+  model-repository/all-minilm-l6-v2/1/vocab.txt \
+  model-repository/all-minilm-l6-v2/1/special_tokens_map.json</div>
+
+  <h3>Edge Cases</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>#</th><th>Input</th><th>Expected Output</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td><code>.env</code> missing</td>
+        <td>Exit 1, message: "Error: .env file not found. Create it with TMDB_API_KEY=..."</td>
+        <td>Guard before any Docker work</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Unknown flag <code>--foo</code></td>
+        <td>Exit 1, usage line printed</td>
+        <td>Catch-all for unrecognised flags</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td><code>HEALTH_TIMEOUT=5</code>, service takes 10 s</td>
+        <td>Exit 1, message names the unhealthy service(s)</td>
+        <td>Timeout enforced; clear error for operator</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td><code>--rebuild</code>, user types "no" at prompt</td>
+        <td>Exit 1, "Aborting." message</td>
+        <td>Confirmation guard prevents accidental data loss</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td><code>--rebuild</code>, user types "yes" at prompt</td>
+        <td>Proceeds to wipe and rebuild</td>
+        <td>Happy path for rebuild</td>
+      </tr>
+      <tr>
+        <td>6</td>
+        <td><code>load-model</code> phase fails during <code>--rebuild</code></td>
+        <td>Exit 1, "load-model phase failed — aborting" message</td>
+        <td>Phase failure propagation</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Access URLs printed on success</h3>
+  <div class="code-block">Services are healthy. Access:
+  Search UI:   http://localhost:8080
+  Qdrant:      http://localhost:6333/dashboard
+  Swagger UI:  http://localhost:8080/swagger-ui/index.html</div>
+
+  <h3>Unit Test Checklist</h3>
+  <p class="prose">Since this is a shell script, tests are verified via <code>bash -n</code> (syntax check) and targeted invocation with controlled inputs:</p>
+  <ul class="criteria-list">
+    <li><code>bash -n start-services.sh</code> exits 0 (no syntax errors)</li>
+    <li>Missing <code>.env</code>: exits 1, stderr/stdout contains "not found"</li>
+    <li>Unrecognised flag <code>--foo</code>: exits 1, output contains "Usage"</li>
+    <li><code>--rebuild</code> with input "no": exits 1 (aborted without docker calls)</li>
+    <li><code>--rebuild</code> with input "yes": proceeds past confirmation (docker calls will fail in unit context — acceptable)</li>
+    <li><code>HEALTH_TIMEOUT</code> is read from environment when set</li>
+  </ul>
+
+  <a class="back-link" href="index.html">← Back to Architecture Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+</body>
+</html>

--- a/docs/stop-services.html
+++ b/docs/stop-services.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Movie Semantic Search — stop-services.sh</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0d1117; color: #e6edf3; min-height: 100vh; }
+  header { border-bottom: 1px solid #30363d; padding: 16px 32px; display: flex; align-items: center; gap: 12px; }
+  header h1 { font-size: 1.1rem; font-weight: 600; color: #e6edf3; }
+  header .breadcrumb { font-size: 0.85rem; color: #8b949e; }
+  main { padding: 32px; max-width: 1200px; margin: 0 auto; }
+  h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 8px; color: #e6edf3; }
+  h3 { font-size: 1.05rem; font-weight: 600; margin: 28px 0 8px; color: #c9d1d9; }
+  h4 { font-size: 0.9rem; font-weight: 600; margin: 16px 0 6px; color: #c9d1d9; }
+  .subtitle { color: #8b949e; font-size: 0.9rem; margin-bottom: 28px; }
+  .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.78rem; font-weight: 600; background: #1f3d2e; color: #3fb950; border: 1px solid #2ea043; margin-bottom: 20px; }
+  .prop-table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 0.875rem; }
+  .prop-table th { text-align: left; padding: 8px 12px; background: #161b22; border: 1px solid #30363d; color: #8b949e; font-weight: 600; }
+  .prop-table td { padding: 8px 12px; border: 1px solid #30363d; vertical-align: top; }
+  .prop-table td:first-child { color: #79c0ff; font-family: "SFMono-Regular", Consolas, monospace; white-space: nowrap; }
+  code { font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.85em; background: #161b22; border: 1px solid #30363d; border-radius: 4px; padding: 1px 5px; color: #79c0ff; }
+  .code-block { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px 20px; font-family: "SFMono-Regular", Consolas, monospace; font-size: 0.82rem; color: #e6edf3; overflow-x: auto; line-height: 1.6; margin-top: 8px; white-space: pre-wrap; word-break: break-all; }
+  .badge-happy { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.75rem; font-weight: 600; background: #1f3d2e; color: #3fb950; border: 1px solid #2ea043; }
+  .badge-error { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.75rem; font-weight: 600; background: #3d1f1f; color: #f85149; border: 1px solid #b91c1c; }
+  .criteria-list { list-style: none; padding: 0; margin-top: 8px; }
+  .criteria-list li { display: flex; align-items: flex-start; gap: 10px; padding: 8px 0; border-bottom: 1px solid #21262d; font-size: 0.875rem; color: #c9d1d9; }
+  .criteria-list li:last-child { border-bottom: none; }
+  .criteria-list li::before { content: "☐"; color: #58a6ff; font-size: 1rem; flex-shrink: 0; line-height: 1.4; }
+  .back-link { display: inline-flex; align-items: center; gap: 6px; color: #58a6ff; text-decoration: none; font-size: 0.85rem; margin-top: 32px; }
+  .back-link:hover { text-decoration: underline; }
+  footer { border-top: 1px solid #30363d; padding: 16px 32px; text-align: center; color: #8b949e; font-size: 0.8rem; margin-top: 48px; }
+  p.prose { color: #8b949e; font-size: 0.9rem; line-height: 1.6; margin-top: 8px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Movie Semantic Search</h1>
+  <span class="breadcrumb">/ <a href="index.html" style="color:#58a6ff;text-decoration:none">Architecture</a> / stop-services.sh</span>
+</header>
+
+<main>
+  <h2>stop-services.sh</h2>
+  <span class="badge">#204 — Add stop-services.sh — single entry-point to stop all services</span>
+  <p class="subtitle">Shell script at the repository root that stops all running Docker Compose containers. By default it preserves volumes for a fast restart; the <code>--clean</code> flag performs a full teardown including volumes.</p>
+
+  <h3>Overview</h3>
+  <p class="prose">
+    <code>stop-services.sh</code> wraps <code>docker compose down</code> with two modes of operation. Without flags it runs <code>docker compose down</code>, leaving named volumes intact so that a subsequent <code>./start-services.sh</code> can restart quickly without re-loading model artifacts or re-populating the database. With <code>--clean</code> it runs <code>docker compose down -v</code>, destroying all named volumes (<code>qdrant_data</code>, <code>model-repository</code>, <code>data</code>) and requiring <code>./start-services.sh --rebuild</code> to restore them. The script exits non-zero with a clear error message if the underlying <code>docker compose down</code> command fails, and prints a usage line and exits non-zero for any unrecognised flag.
+  </p>
+
+  <h3>Flags</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Flag</th><th>Command run</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>(none)</td>
+        <td><code>docker compose down</code></td>
+        <td>Stop and remove containers. Named volumes are preserved. Prints a confirmation that volumes were preserved and that <code>./start-services.sh</code> can be used to restart quickly.</td>
+      </tr>
+      <tr>
+        <td>--clean</td>
+        <td><code>docker compose down -v</code></td>
+        <td>Full teardown: stop containers and destroy all named volumes. Prints a warning that volumes (embeddings, model artifacts, database data) have been removed and that <code>./start-services.sh --rebuild</code> will be required next time.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Data Contract</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Property</th><th>Type</th><th>Description</th><th>Behavior</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Exit code</td>
+        <td>integer</td>
+        <td>Exit code of the script</td>
+        <td>0 on success; non-zero if <code>docker compose down</code> fails or an unrecognised flag is supplied</td>
+      </tr>
+      <tr>
+        <td>stdout</td>
+        <td>string</td>
+        <td>Status and error messages</td>
+        <td>See message formats below</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Message Formats</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Event</th><th>Message</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Default mode success</td>
+        <td>Confirmation that services have stopped and volumes are preserved; instructs user to run <code>./start-services.sh</code> to restart</td>
+      </tr>
+      <tr>
+        <td>--clean mode success</td>
+        <td>Warning that volumes (embeddings, model artifacts, database data) have been removed; instructs user to run <code>./start-services.sh --rebuild</code> next time</td>
+      </tr>
+      <tr>
+        <td>docker compose down fails</td>
+        <td>Clear error message indicating failure; exits non-zero</td>
+      </tr>
+      <tr>
+        <td>Unrecognised flag</td>
+        <td>Usage line (e.g. <code>Usage: ./stop-services.sh [--clean]</code>); exits non-zero</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>Observable Output Examples</h4>
+  <div class="code-block">$ ./stop-services.sh
+[docker compose output...]
+Services stopped. Volumes preserved — run ./start-services.sh to restart quickly.</div>
+
+  <div class="code-block" style="margin-top:12px;">$ ./stop-services.sh --clean
+[docker compose output...]
+WARNING: Volumes removed (embeddings, model artifacts, database data).
+Run ./start-services.sh --rebuild next time to restore them.</div>
+
+  <div class="code-block" style="margin-top:12px;">$ ./stop-services.sh --unknown
+Usage: ./stop-services.sh [--clean]
+$ echo $?
+1</div>
+
+  <h3>Dependencies</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Dependency</th><th>Interface / Type</th><th>Injected As</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>docker compose</td>
+        <td>CLI command</td>
+        <td>Invoked via <code>docker compose down</code> or <code>docker compose down -v</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h4>docker compose — Mock Behaviors</h4>
+  <table class="prop-table">
+    <thead>
+      <tr><th>Scenario</th><th>Behavior</th><th>Badge</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Default stop succeeds</td>
+        <td><code>docker compose down</code> exits 0; script prints volume-preserved confirmation and exits 0</td>
+        <td><span class="badge-happy">happy</span></td>
+      </tr>
+      <tr>
+        <td>Clean stop succeeds</td>
+        <td><code>docker compose down -v</code> exits 0; script prints volume-removed warning and exits 0</td>
+        <td><span class="badge-happy">happy</span></td>
+      </tr>
+      <tr>
+        <td>docker compose down fails</td>
+        <td><code>docker compose down</code> exits non-zero; script prints error message and propagates the exit code</td>
+        <td><span class="badge-error">error</span></td>
+      </tr>
+      <tr>
+        <td>Unrecognised flag supplied</td>
+        <td>Script prints usage line and exits non-zero without invoking <code>docker compose</code></td>
+        <td><span class="badge-error">error</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Edge Cases</h3>
+  <table class="prop-table">
+    <thead>
+      <tr><th>#</th><th>Input</th><th>Expected Output</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>No flags; <code>docker compose down</code> exits 0</td>
+        <td>Exit code 0; stdout confirms volumes preserved and restart path</td>
+        <td>Normal stop, volumes kept</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td><code>--clean</code>; <code>docker compose down -v</code> exits 0</td>
+        <td>Exit code 0; stdout warns volumes removed and requires <code>--rebuild</code></td>
+        <td>Full teardown including volumes</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>No flags; <code>docker compose down</code> exits non-zero</td>
+        <td>Exit code non-zero; stdout contains error message</td>
+        <td>Compose failure propagated</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td>Unrecognised flag (e.g. <code>--foo</code>)</td>
+        <td>Exit code non-zero; stdout contains usage line; <code>docker compose</code> never invoked</td>
+        <td>Bad flag rejected with usage guidance</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>Unit Test Checklist</h3>
+  <p class="prose">Shell scripts have no Python unit tests. All behavior is verified by the integration test suite. The observable contract above defines what integration tests must assert:</p>
+  <ul class="criteria-list" style="margin-top:12px;">
+    <li>Default mode: exit code 0; stdout confirms volumes are preserved and instructs user to run <code>./start-services.sh</code></li>
+    <li>--clean mode: exit code 0; stdout warns that volumes (embeddings, model artifacts, database data) have been removed and instructs user to run <code>./start-services.sh --rebuild</code></li>
+    <li>docker compose down fails: exit code non-zero; stdout contains a clear error message</li>
+    <li>Unrecognised flag: exit code non-zero; stdout contains a usage line; <code>docker compose</code> is not invoked</li>
+  </ul>
+
+  <a class="back-link" href="index.html">← Back to Architecture Overview</a>
+</main>
+
+<footer>Movie Semantic Search &mdash; <a href="https://github.com/atefft/movie-semantic-search" style="color:#58a6ff">GitHub</a></footer>
+
+</body>
+</html>

--- a/pipeline/tests/test_executive_guide_205.py
+++ b/pipeline/tests/test_executive_guide_205.py
@@ -1,0 +1,54 @@
+import re
+
+HTML_PATH = "docs/executive-guide.html"
+
+
+def read_html():
+    with open(HTML_PATH) as f:
+        return f.read()
+
+
+def test_no_old_docker_commands():
+    html = read_html()
+    assert "docker compose run --rm load-model" not in html
+    assert "docker compose up -d" not in html
+    assert "docker compose run --rm load-data" not in html
+
+
+def test_rebuild_flag_present_twice():
+    html = read_html()
+    assert html.count("start-services.sh --rebuild") >= 2
+
+
+def test_no_flag_startup_mentioned():
+    html = read_html()
+    assert "start-services.sh" in html  # no-flag variant mentioned
+
+
+def test_stop_services_present():
+    html = read_html()
+    assert "stop-services.sh" in html
+    assert "stop-services.sh --clean" in html
+
+
+def test_stopping_services_section():
+    html = read_html()
+    assert 'id="stopping-services"' in html
+
+
+def test_toc_stopping_services_link():
+    html = read_html()
+    assert '#stopping-services' in html
+
+
+def test_uat_note_present():
+    html = read_html()
+    assert "/uat" in html
+
+
+def test_preserved_content():
+    html = read_html()
+    assert "TMDB" in html
+    assert "localhost:6333" in html
+    assert "localhost:8080" in html
+    assert "docker.com" in html or "docker.com/products" in html

--- a/pipeline/tests/test_start_services_integration.sh
+++ b/pipeline/tests/test_start_services_integration.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Integration tests for start-services.sh
+# Run from the repository root: bash pipeline/tests/test_start_services_integration.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() { echo "PASS: $1"; ((PASS++)); }
+fail() { echo "FAIL: $1"; ((FAIL++)); FAILURES+=("$1"); }
+
+# ---------------------------------------------------------------------------
+# Test 1 — .env guard
+# ---------------------------------------------------------------------------
+run_test1() {
+  local name="test1_env_guard"
+  local saved=false
+  if [[ -f "$REPO_ROOT/.env" ]]; then
+    mv "$REPO_ROOT/.env" "$REPO_ROOT/.env.bak"
+    saved=true
+  fi
+
+  local output exit_code
+  output=$(bash "$REPO_ROOT/start-services.sh" 2>&1)
+  exit_code=$?
+
+  if $saved; then
+    mv "$REPO_ROOT/.env.bak" "$REPO_ROOT/.env"
+  fi
+
+  if [[ $exit_code -eq 1 ]] && echo "$output" | grep -qi "not found"; then
+    pass "$name"
+  else
+    fail "$name (exit=$exit_code, output=$output)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 2 — unknown flag
+# ---------------------------------------------------------------------------
+run_test2() {
+  local name="test2_unknown_flag"
+  local output exit_code
+  output=$(bash "$REPO_ROOT/start-services.sh" --unknown-flag 2>&1)
+  exit_code=$?
+
+  if [[ $exit_code -eq 1 ]] && echo "$output" | grep -qi "usage"; then
+    pass "$name"
+  else
+    fail "$name (exit=$exit_code, output=$output)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 3 — default path healthy poll
+# ---------------------------------------------------------------------------
+run_test3() {
+  local name="test3_default_path_healthy"
+
+  if [[ ! -f "$REPO_ROOT/.env" ]]; then
+    fail "$name (skipped: .env file not present)"
+    return
+  fi
+
+  docker compose -f "$REPO_ROOT/docker-compose.yml" up -d 2>&1
+
+  local output exit_code
+  output=$(HEALTH_TIMEOUT=180 bash "$REPO_ROOT/start-services.sh" 2>&1)
+  exit_code=$?
+
+  if [[ $exit_code -eq 0 ]] && echo "$output" | grep -q "http://localhost:8080"; then
+    pass "$name"
+  else
+    fail "$name (exit=$exit_code, output=$output)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 4 — --rebuild abort
+# ---------------------------------------------------------------------------
+run_test4() {
+  local name="test4_rebuild_abort"
+  local output exit_code
+  output=$(echo "no" | bash "$REPO_ROOT/start-services.sh" --rebuild 2>&1)
+  exit_code=$?
+
+  if [[ $exit_code -eq 1 ]] && echo "$output" | grep -q "Aborting."; then
+    pass "$name"
+  else
+    fail "$name (exit=$exit_code, output=$output)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 5 — --rebuild full pipeline
+# ---------------------------------------------------------------------------
+run_test5() {
+  local name="test5_rebuild_full_pipeline"
+
+  if [[ ! -f "$REPO_ROOT/.env" ]]; then
+    fail "$name (skipped: .env file not present)"
+    return
+  fi
+
+  local output exit_code
+  output=$(echo "yes" | HEALTH_TIMEOUT=300 bash "$REPO_ROOT/start-services.sh" --rebuild 2>&1)
+  exit_code=$?
+
+  if [[ $exit_code -eq 0 ]] && echo "$output" | grep -q "http://localhost:8080"; then
+    pass "$name"
+  else
+    fail "$name (exit=$exit_code, output=$output)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+echo "=== start-services.sh integration tests ==="
+echo "Repo root: $REPO_ROOT"
+echo ""
+
+run_test1
+run_test2
+run_test3
+run_test4
+run_test5
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ $FAIL -gt 0 ]]; then
+  echo "Failed tests:"
+  for t in "${FAILURES[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi
+
+exit 0

--- a/start-services.sh
+++ b/start-services.sh
@@ -15,42 +15,60 @@ for arg in "$@"; do
   esac
 done
 
+if [[ "$REBUILD" == "true" ]]; then
+  echo "WARNING: --rebuild will stop all containers, remove volumes (all loaded data will be lost),"
+  echo "and remove locally-built Docker images. This cannot be undone."
+  read -rp "Type 'yes' to continue: " confirm
+  if [[ "$confirm" != "yes" ]]; then
+    echo "Aborting."
+    exit 1
+  fi
+fi
+
 if [[ ! -f .env ]]; then
   echo "Error: .env file not found. Create it with TMDB_API_KEY=<your-key>" >&2
   exit 1
 fi
 
-if [[ "$REBUILD" == "true" ]]; then
-  echo "--rebuild not yet implemented" >&2
-  exit 1
-fi
-
-docker compose up -d
-
 HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-120}
-deadline=$((SECONDS + HEALTH_TIMEOUT))
 
-while [[ $SECONDS -lt $deadline ]]; do
-  if curl -sf http://localhost:8000/v2/health/ready >/dev/null 2>&1 && \
-     curl -sf http://localhost:6333/healthz        >/dev/null 2>&1 && \
-     curl -sf http://localhost:8080/api/operator/health >/dev/null 2>&1; then
-    break
-  fi
-  sleep 5
-done
+wait_for_healthy() {
+  local deadline=$((SECONDS + HEALTH_TIMEOUT))
+  while [[ $SECONDS -lt $deadline ]]; do
+    if curl -sf http://localhost:8000/v2/health/ready >/dev/null 2>&1 && \
+       curl -sf http://localhost:6333/healthz        >/dev/null 2>&1 && \
+       curl -sf http://localhost:8080/api/operator/health >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 5
+  done
+  for name_url in "triton http://localhost:8000/v2/health/ready" \
+                  "qdrant http://localhost:6333/healthz" \
+                  "api http://localhost:8080/api/operator/health"; do
+    name=${name_url%% *}; url=${name_url#* }
+    curl -sf "$url" >/dev/null 2>&1 || echo "Error: $name did not become healthy within ${HEALTH_TIMEOUT}s" >&2
+  done
+  return 1
+}
 
-if ! curl -sf http://localhost:8000/v2/health/ready >/dev/null 2>&1; then
-  echo "Error: service triton did not become healthy within ${HEALTH_TIMEOUT}s" >&2
-  exit 1
+if [[ "$REBUILD" == "true" ]]; then
+  docker compose down --rmi local -v
+
+  rm -rf data/raw/ data/embeddings/ \
+    model-repository/all-minilm-l6-v2/1/model.onnx \
+    model-repository/all-minilm-l6-v2/1/tokenizer.json \
+    model-repository/all-minilm-l6-v2/1/tokenizer_config.json \
+    model-repository/all-minilm-l6-v2/1/vocab.txt \
+    model-repository/all-minilm-l6-v2/1/special_tokens_map.json
+
+  docker compose run --rm load-model || (echo "[rebuild] load-model phase failed — aborting" && exit 1)
+  docker compose up -d || (echo "[rebuild] services-up phase failed — aborting" && exit 1)
+  docker compose run --rm load-data || (echo "[rebuild] load-data phase failed — aborting" && exit 1)
+else
+  docker compose up -d
 fi
-if ! curl -sf http://localhost:6333/healthz >/dev/null 2>&1; then
-  echo "Error: service qdrant did not become healthy within ${HEALTH_TIMEOUT}s" >&2
-  exit 1
-fi
-if ! curl -sf http://localhost:8080/api/operator/health >/dev/null 2>&1; then
-  echo "Error: service api did not become healthy within ${HEALTH_TIMEOUT}s" >&2
-  exit 1
-fi
+
+wait_for_healthy || exit 1
 
 echo "Services are healthy. Access:"
 echo "  Search UI:   http://localhost:8080"

--- a/start-services.sh
+++ b/start-services.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REBUILD=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --rebuild)
+      REBUILD=true
+      ;;
+    *)
+      echo "Usage: ./start-services.sh [--rebuild]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f .env ]]; then
+  echo "Error: .env file not found. Create it with TMDB_API_KEY=<your-key>" >&2
+  exit 1
+fi
+
+if [[ "$REBUILD" == "true" ]]; then
+  echo "--rebuild not yet implemented" >&2
+  exit 1
+fi
+
+docker compose up -d
+
+HEALTH_TIMEOUT=${HEALTH_TIMEOUT:-120}
+deadline=$((SECONDS + HEALTH_TIMEOUT))
+
+while [[ $SECONDS -lt $deadline ]]; do
+  if curl -sf http://localhost:8000/v2/health/ready >/dev/null 2>&1 && \
+     curl -sf http://localhost:6333/healthz        >/dev/null 2>&1 && \
+     curl -sf http://localhost:8080/api/operator/health >/dev/null 2>&1; then
+    break
+  fi
+  sleep 5
+done
+
+if ! curl -sf http://localhost:8000/v2/health/ready >/dev/null 2>&1; then
+  echo "Error: service triton did not become healthy within ${HEALTH_TIMEOUT}s" >&2
+  exit 1
+fi
+if ! curl -sf http://localhost:6333/healthz >/dev/null 2>&1; then
+  echo "Error: service qdrant did not become healthy within ${HEALTH_TIMEOUT}s" >&2
+  exit 1
+fi
+if ! curl -sf http://localhost:8080/api/operator/health >/dev/null 2>&1; then
+  echo "Error: service api did not become healthy within ${HEALTH_TIMEOUT}s" >&2
+  exit 1
+fi
+
+echo "Services are healthy. Access:"
+echo "  Search UI:   http://localhost:8080"
+echo "  Qdrant:      http://localhost:6333/dashboard"
+echo "  Swagger UI:  http://localhost:8080/swagger-ui/index.html"

--- a/stop-services.sh
+++ b/stop-services.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+
+# Detect docker compose command
+if docker compose version &>/dev/null 2>&1; then
+  DC="docker compose"
+elif docker-compose version &>/dev/null 2>&1; then
+  DC="docker-compose"
+else
+  echo "Error: neither 'docker compose' nor 'docker-compose' is available" >&2
+  exit 1
+fi
+
+CLEAN=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --clean) CLEAN=true ;;
+    *) echo "Usage: stop-services.sh [--clean]" >&2; exit 1 ;;
+  esac
+done
+
+if [ "$CLEAN" = true ]; then
+  $DC down -v
+  status=$?
+  if [ $status -ne 0 ]; then
+    echo "Error: docker compose down -v failed (exit $status)" >&2
+    exit 1
+  fi
+  echo "WARNING: Volumes removed (qdrant_data, model-repository, data). Run ./start-services.sh --rebuild to reinitialise."
+else
+  $DC down
+  status=$?
+  if [ $status -ne 0 ]; then
+    echo "Error: docker compose down failed (exit $status)" >&2
+    exit 1
+  fi
+  echo "Services stopped. Volumes preserved — run ./start-services.sh to restart quickly."
+fi

--- a/tests/test_stop_services.sh
+++ b/tests/test_stop_services.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+
+# Unit tests for stop-services.sh
+# Uses a mock docker binary on PATH — no bats required.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MOCK_BIN="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() {
+  rm -rf "$MOCK_BIN"
+}
+trap cleanup EXIT
+
+run_test() {
+  local name="$1"
+  local result="$2"
+  if [ "$result" = "pass" ]; then
+    echo "PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Write a mock docker that responds to subcommands
+setup_mock_docker() {
+  local compose_v2_exit="${1:-0}"   # exit code for "docker compose version"
+  local compose_down_exit="${2:-0}" # exit code for "docker compose down"
+
+  cat > "$MOCK_BIN/docker" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "compose" ] && [ "\$2" = "version" ]; then
+  exit $compose_v2_exit
+fi
+if [ "\$1" = "compose" ] && [ "\$2" = "down" ]; then
+  exit $compose_down_exit
+fi
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/docker"
+  rm -f "$MOCK_BIN/docker-compose"
+}
+
+setup_mock_docker_v1_only() {
+  local v1_down_exit="${1:-0}"
+
+  # docker (V2 plugin) always fails for compose subcommand
+  cat > "$MOCK_BIN/docker" <<'DOCKEREOF'
+#!/usr/bin/env bash
+if [ "$1" = "compose" ]; then
+  exit 1
+fi
+exit 0
+DOCKEREOF
+  chmod +x "$MOCK_BIN/docker"
+
+  cat > "$MOCK_BIN/docker-compose" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "version" ]; then
+  exit 0
+fi
+if [ "\$1" = "down" ]; then
+  exit $v1_down_exit
+fi
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/docker-compose"
+}
+
+setup_mock_no_docker() {
+  # Neither docker compose nor docker-compose available
+  cat > "$MOCK_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$MOCK_BIN/docker"
+  rm -f "$MOCK_BIN/docker-compose"
+}
+
+# -----------------------------------------------------------------------
+# Test 1: script exists and is executable
+# -----------------------------------------------------------------------
+test_script_executable() {
+  if [ -x "$SCRIPT_DIR/stop-services.sh" ]; then
+    run_test "script exists and is executable" "pass"
+  else
+    run_test "script exists and is executable" "fail"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Test 2: default mode (no flags) — exits 0, stdout contains expected text
+# -----------------------------------------------------------------------
+test_default_mode() {
+  setup_mock_docker 0 0
+  output=$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_DIR/stop-services.sh" 2>&1)
+  exit_code=$?
+  if [ $exit_code -eq 0 ] \
+      && echo "$output" | grep -q "Volumes preserved" \
+      && echo "$output" | grep -q "./start-services.sh"; then
+    run_test "default mode: exits 0 and stdout contains expected text" "pass"
+  else
+    run_test "default mode: exits 0 and stdout contains expected text" "fail"
+    echo "  exit_code=$exit_code output=$output"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Test 3: --clean mode — exits 0, stdout contains WARNING and volume names
+# -----------------------------------------------------------------------
+test_clean_mode() {
+  setup_mock_docker 0 0
+  output=$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_DIR/stop-services.sh" --clean 2>&1)
+  exit_code=$?
+  if [ $exit_code -eq 0 ] \
+      && echo "$output" | grep -q "WARNING" \
+      && echo "$output" | grep -q "qdrant_data" \
+      && echo "$output" | grep -q "model-repository" \
+      && echo "$output" | grep -q "data" \
+      && echo "$output" | grep -q "./start-services.sh --rebuild"; then
+    run_test "--clean mode: exits 0 and stdout contains WARNING and volume names" "pass"
+  else
+    run_test "--clean mode: exits 0 and stdout contains WARNING and volume names" "fail"
+    echo "  exit_code=$exit_code output=$output"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Test 4: compose command exits non-zero in default mode
+# -----------------------------------------------------------------------
+test_compose_failure_default() {
+  setup_mock_docker 0 1
+  stderr=$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_DIR/stop-services.sh" 2>&1 1>/dev/null)
+  exit_code=$?
+  if [ $exit_code -ne 0 ] && echo "$stderr" | grep -q "Error: docker compose down failed"; then
+    run_test "docker compose down failure: exits non-zero and stderr contains error message" "pass"
+  else
+    run_test "docker compose down failure: exits non-zero and stderr contains error message" "fail"
+    echo "  exit_code=$exit_code stderr=$stderr"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Test 5: compose command exits non-zero in --clean mode
+# -----------------------------------------------------------------------
+test_compose_failure_clean() {
+  # Need a mock that fails on "down -v"
+  cat > "$MOCK_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "compose" ] && [ "$2" = "down" ]; then
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/docker"
+
+  stderr=$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_DIR/stop-services.sh" --clean 2>&1 1>/dev/null)
+  exit_code=$?
+  if [ $exit_code -ne 0 ] && echo "$stderr" | grep -q "Error: docker compose down"; then
+    run_test "docker compose down -v failure: exits non-zero and stderr contains error message" "pass"
+  else
+    run_test "docker compose down -v failure: exits non-zero and stderr contains error message" "fail"
+    echo "  exit_code=$exit_code stderr=$stderr"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Test 6: unrecognised flag — exits non-zero, stderr contains usage
+# -----------------------------------------------------------------------
+test_unrecognised_flag() {
+  setup_mock_docker 0 0
+  stderr=$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_DIR/stop-services.sh" --unknown 2>&1 1>/dev/null)
+  exit_code=$?
+  if [ $exit_code -ne 0 ] && echo "$stderr" | grep -q "Usage: stop-services.sh \[--clean\]"; then
+    run_test "unrecognised flag: exits non-zero and stderr contains usage" "pass"
+  else
+    run_test "unrecognised flag: exits non-zero and stderr contains usage" "fail"
+    echo "  exit_code=$exit_code stderr=$stderr"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Test 7: neither docker compose nor docker-compose available
+# -----------------------------------------------------------------------
+test_no_docker() {
+  setup_mock_no_docker
+  stderr=$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_DIR/stop-services.sh" 2>&1 1>/dev/null)
+  exit_code=$?
+  if [ $exit_code -eq 1 ] && echo "$stderr" | grep -q "neither 'docker compose' nor 'docker-compose' is available"; then
+    run_test "no docker available: exits 1 and stderr contains expected message" "pass"
+  else
+    run_test "no docker available: exits 1 and stderr contains expected message" "fail"
+    echo "  exit_code=$exit_code stderr=$stderr"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Test 8: V1 fallback — uses docker-compose when docker compose version fails
+# -----------------------------------------------------------------------
+test_v1_fallback() {
+  setup_mock_docker_v1_only 0
+  output=$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_DIR/stop-services.sh" 2>&1)
+  exit_code=$?
+  if [ $exit_code -eq 0 ] && echo "$output" | grep -q "Volumes preserved"; then
+    run_test "V1 fallback: uses docker-compose when V2 unavailable" "pass"
+  else
+    run_test "V1 fallback: uses docker-compose when V2 unavailable" "fail"
+    echo "  exit_code=$exit_code output=$output"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Test 9: V2 preferred over V1 when both available
+# -----------------------------------------------------------------------
+test_v2_preferred() {
+  setup_mock_docker 0 0
+  # Also add docker-compose that would fail if called
+  cat > "$MOCK_BIN/docker-compose" <<'EOF'
+#!/usr/bin/env bash
+exit 42
+EOF
+  chmod +x "$MOCK_BIN/docker-compose"
+
+  output=$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_DIR/stop-services.sh" 2>&1)
+  exit_code=$?
+  if [ $exit_code -eq 0 ] && echo "$output" | grep -q "Volumes preserved"; then
+    run_test "V2 preferred over V1 when both available" "pass"
+  else
+    run_test "V2 preferred over V1 when both available" "fail"
+    echo "  exit_code=$exit_code output=$output"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# Run all tests
+# -----------------------------------------------------------------------
+test_script_executable
+test_default_mode
+test_clean_mode
+test_compose_failure_default
+test_compose_failure_clean
+test_unrecognised_flag
+test_no_docker
+test_v1_fallback
+test_v2_preferred
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]

--- a/tests/test_stop_services_integration.sh
+++ b/tests/test_stop_services_integration.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE_ARGS=(-f "$REPO_ROOT/docker-compose.yml" -f "$REPO_ROOT/docker-compose.ci.yml")
+PASS=0
+FAIL=0
+
+cleanup() {
+  docker compose "${COMPOSE_ARGS[@]}" down -v &>/dev/null || true
+}
+trap cleanup EXIT
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== Integration test: stop-services.sh ==="
+
+# ---- Test 1: default stop (no --clean) preserves qdrant_data volume ----
+echo ""
+echo "--- Test 1: default stop preserves qdrant_data volume ---"
+
+docker compose "${COMPOSE_ARGS[@]}" up -d --wait --wait-timeout 120
+# Discover the actual compose-managed volume name (e.g. movie-semantic-search_qdrant_data)
+PROJECT_VOLUME=$(docker volume ls -q | grep '_qdrant_data$' | head -1)
+
+"$REPO_ROOT/stop-services.sh"
+
+running=$(docker compose "${COMPOSE_ARGS[@]}" ps -q 2>/dev/null)
+if [ -z "$running" ]; then
+  pass "No containers running after stop-services.sh"
+else
+  fail "Containers still running after stop-services.sh: $running"
+fi
+
+if docker volume inspect "$PROJECT_VOLUME" &>/dev/null; then
+  pass "qdrant_data volume preserved after default stop"
+else
+  fail "qdrant_data volume was removed after default stop (expected to be preserved)"
+fi
+
+# ---- Test 2: --clean stop removes qdrant_data volume ----
+echo ""
+echo "--- Test 2: --clean stop removes qdrant_data volume ---"
+
+docker compose "${COMPOSE_ARGS[@]}" up -d --wait --wait-timeout 120
+
+"$REPO_ROOT/stop-services.sh" --clean
+
+running=$(docker compose "${COMPOSE_ARGS[@]}" ps -q 2>/dev/null)
+if [ -z "$running" ]; then
+  pass "No containers running after stop-services.sh --clean"
+else
+  fail "Containers still running after stop-services.sh --clean: $running"
+fi
+
+if ! docker volume inspect "$PROJECT_VOLUME" &>/dev/null; then
+  pass "qdrant_data volume removed after --clean stop"
+else
+  fail "qdrant_data volume still exists after --clean stop (expected removal)"
+fi
+
+# ---- Summary ----
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
Fixes API localhost hardcoding that prevented Triton and Qdrant from being reachable inside the Docker Compose network, plus two related correctness fixes discovered during verification.

## Changes
- `api/src/main/resources/application.yml` — replaced hardcoded `localhost` for `triton.host` and `qdrant.base-url` with `${TRITON_HOST:localhost}` and `${QDRANT_BASE_URL:http://localhost:6333}` env var placeholders; corrected `model-name` from `all-MiniLM-L6-v2` to `all-minilm-l6-v2` (must match Triton model directory name)
- `docker-compose.yml` — added `TRITON_HOST=triton` and `QDRANT_BASE_URL=http://qdrant:6333` to the `api` service environment block
- `api/src/main/java/com/moviesearch/service/impl/QdrantServiceManagerImpl.java` — fixed health check endpoint from `/health` (404) to `/healthz` (200) so `"qdrant":true` is reported correctly
- `api/src/test/java/com/moviesearch/service/impl/QdrantServiceManagerImplTest.java` — updated URI assertion to match `/healthz`
- `api/src/test/java/com/moviesearch/config/TritonPropertiesTest.java` — updated expected model name to `all-minilm-l6-v2`

## Verification
All 206 Java tests pass. Full end-to-end search verification (Docker Compose `start-services.sh` → health → search) to be confirmed by user on host.

Closes #207