### PR TITLE
[Bug Roundup #207] Bug roundup: 1 bug — API localhost hardcoding breaks Docker Compose search

### DIFF
--- a/api/src/main/java/com/moviesearch/service/impl/QdrantServiceManagerImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/QdrantServiceManagerImpl.java
@@ -60,7 +60,7 @@ public class QdrantServiceManagerImpl implements QdrantServiceManager {
     public ServiceStatus getStatus() {
         try {
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(qdrantProperties.getBaseUrl() + "/health"))
+                    .uri(URI.create(qdrantProperties.getBaseUrl() + "/healthz"))
                     .GET()
                     .build();
             HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,11 +1,11 @@
 triton:
-  host: localhost
+  host: ${TRITON_HOST:localhost}
   port: 8001
-  model-name: all-MiniLM-L6-v2
+  model-name: all-minilm-l6-v2
   deadline-ms: 5000
 
 qdrant:
-  base-url: http://localhost:6333
+  base-url: ${QDRANT_BASE_URL:http://localhost:6333}
   mock: false
 
 search:

--- a/api/src/test/java/com/moviesearch/config/TritonPropertiesTest.java
+++ b/api/src/test/java/com/moviesearch/config/TritonPropertiesTest.java
@@ -14,7 +14,7 @@ class TritonPropertiesTest {
 
     @Test
     void defaultModelNameIsAllMiniLML6v2() {
-        assertThat(tritonProperties.getModelName()).isEqualTo("all-MiniLM-L6-v2");
+        assertThat(tritonProperties.getModelName()).isEqualTo("all-minilm-l6-v2");
     }
 
     @Test

--- a/api/src/test/java/com/moviesearch/service/impl/QdrantServiceManagerImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/QdrantServiceManagerImplTest.java
@@ -162,7 +162,7 @@ class QdrantServiceManagerImplTest {
         manager.getStatus();
 
         verify(httpClient).send(
-                org.mockito.ArgumentMatchers.argThat(req -> req.uri().toString().equals("http://localhost:6333/health")),
+                org.mockito.ArgumentMatchers.argThat(req -> req.uri().toString().equals("http://localhost:6333/healthz")),
                 any(HttpResponse.BodyHandler.class));
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
 
   api:
     build: .
+    environment:
+      - TRITON_HOST=triton
+      - QDRANT_BASE_URL=http://qdrant:6333
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
## Summary
Fixes localhost hardcoding in the API that prevented Triton and Qdrant from being reachable inside the Docker Compose network, plus two correlated correctness fixes discovered during verification (wrong health endpoint, wrong model-name casing).

## Merged task PRs
- #253 Fix localhost hardcoding for Triton/Qdrant in Docker Compose https://github.com/atefft/movie-semantic-search/pull/253

## Verification
All acceptance criteria from #207 were verified through task PRs. CI runs as part of this PR.

Closes #207
- Closes #206 — Bug: API uses localhost for Triton/Qdrant, breaking search in Docker