### PR TITLE
Fix executive-guide walkthrough: wire API to real Triton model + start-services rebuild

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -79,6 +79,13 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.3.0</version>
         </dependency>
+
+        <!-- HuggingFace tokenizer (JNI binding via DJL) for query tokenization -->
+        <dependency>
+            <groupId>ai.djl.huggingface</groupId>
+            <artifactId>tokenizers</artifactId>
+            <version>0.27.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/com/moviesearch/config/TritonProperties.java
+++ b/api/src/main/java/com/moviesearch/config/TritonProperties.java
@@ -14,6 +14,24 @@ public class TritonProperties {
     private String modelName = "all-MiniLM-L6-v2";
     private long deadlineMs = 5000;
     private boolean mock = false;
+    private int maxLength = 128;
+    private String tokenizerPath = "/app/tokenizer/tokenizer.json";
+
+    public int getMaxLength() {
+        return maxLength;
+    }
+
+    public void setMaxLength(int maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    public String getTokenizerPath() {
+        return tokenizerPath;
+    }
+
+    public void setTokenizerPath(String tokenizerPath) {
+        this.tokenizerPath = tokenizerPath;
+    }
 
     public String getHost() {
         return host;

--- a/api/src/main/java/com/moviesearch/model/TokenizedInput.java
+++ b/api/src/main/java/com/moviesearch/model/TokenizedInput.java
@@ -1,0 +1,36 @@
+package com.moviesearch.model;
+
+public final class TokenizedInput {
+
+    private final long[] inputIds;
+    private final long[] attentionMask;
+    private final long[] tokenTypeIds;
+
+    public TokenizedInput(long[] inputIds, long[] attentionMask, long[] tokenTypeIds) {
+        if (inputIds.length != attentionMask.length || inputIds.length != tokenTypeIds.length) {
+            throw new IllegalArgumentException(
+                "TokenizedInput arrays must have equal length: inputIds=" + inputIds.length
+                    + ", attentionMask=" + attentionMask.length
+                    + ", tokenTypeIds=" + tokenTypeIds.length);
+        }
+        this.inputIds = inputIds;
+        this.attentionMask = attentionMask;
+        this.tokenTypeIds = tokenTypeIds;
+    }
+
+    public long[] getInputIds() {
+        return inputIds;
+    }
+
+    public long[] getAttentionMask() {
+        return attentionMask;
+    }
+
+    public long[] getTokenTypeIds() {
+        return tokenTypeIds;
+    }
+
+    public int length() {
+        return inputIds.length;
+    }
+}

--- a/api/src/main/java/com/moviesearch/service/QueryTokenizer.java
+++ b/api/src/main/java/com/moviesearch/service/QueryTokenizer.java
@@ -1,0 +1,8 @@
+package com.moviesearch.service;
+
+import com.moviesearch.model.TokenizedInput;
+
+public interface QueryTokenizer {
+
+    TokenizedInput tokenize(String text);
+}

--- a/api/src/main/java/com/moviesearch/service/impl/EmbeddingServiceImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/EmbeddingServiceImpl.java
@@ -5,7 +5,9 @@ import com.moviesearch.config.TritonProperties;
 import com.moviesearch.exception.EmbeddingServiceException;
 import com.moviesearch.model.EmbeddingRequest;
 import com.moviesearch.model.EmbeddingResponse;
+import com.moviesearch.model.TokenizedInput;
 import com.moviesearch.service.EmbeddingService;
+import com.moviesearch.service.QueryTokenizer;
 import inference.GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingStub;
 import inference.Inference.InferTensorContents;
 import inference.Inference.ModelInferRequest;
@@ -17,6 +19,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -26,12 +31,21 @@ public class EmbeddingServiceImpl implements EmbeddingService {
 
     private static final Logger log = LoggerFactory.getLogger(EmbeddingServiceImpl.class);
     private static final int VECTOR_DIM = 384;
+    private static final String INPUT_IDS = "input_ids";
+    private static final String ATTENTION_MASK = "attention_mask";
+    private static final String TOKEN_TYPE_IDS = "token_type_ids";
+    private static final String OUTPUT_TOKEN_EMBEDDINGS = "token_embeddings";
+    private static final String INT64 = "INT64";
 
     private final GRPCInferenceServiceBlockingStub stub;
+    private final QueryTokenizer tokenizer;
     private final TritonProperties props;
 
-    public EmbeddingServiceImpl(GRPCInferenceServiceBlockingStub stub, TritonProperties props) {
+    public EmbeddingServiceImpl(GRPCInferenceServiceBlockingStub stub,
+                                QueryTokenizer tokenizer,
+                                TritonProperties props) {
         this.stub = stub;
+        this.tokenizer = tokenizer;
         this.props = props;
     }
 
@@ -41,16 +55,16 @@ public class EmbeddingServiceImpl implements EmbeddingService {
         String textPreview = text.length() > 50 ? text.substring(0, 50) : text;
         log.debug("EmbeddingService.embed called [text='{}']", textPreview);
 
+        TokenizedInput tokens = tokenizer.tokenize(text);
+        int seqLen = tokens.length();
+
         ModelInferRequest grpcRequest = ModelInferRequest.newBuilder()
             .setModelName(props.getModelName())
-            .addInputs(ModelInferRequest.InferInputTensor.newBuilder()
-                .setName("TEXT")
-                .setDatatype("BYTES")
-                .addShape(1).addShape(1)
-                .setContents(InferTensorContents.newBuilder()
-                    .addBytesContents(ByteString.copyFromUtf8(text))))
+            .addInputs(buildIntInput(INPUT_IDS, seqLen, tokens.getInputIds()))
+            .addInputs(buildIntInput(ATTENTION_MASK, seqLen, tokens.getAttentionMask()))
+            .addInputs(buildIntInput(TOKEN_TYPE_IDS, seqLen, tokens.getTokenTypeIds()))
             .addOutputs(ModelInferRequest.InferRequestedOutputTensor.newBuilder()
-                .setName("sentence_embedding"))
+                .setName(OUTPUT_TOKEN_EMBEDDINGS))
             .build();
 
         ModelInferResponse response;
@@ -62,18 +76,77 @@ public class EmbeddingServiceImpl implements EmbeddingService {
             throw mapException(e);
         }
 
-        List<Float> floats = response.getOutputs(0).getContents().getFp32ContentsList();
-        if (floats.size() != VECTOR_DIM) {
-            throw new EmbeddingServiceException(EmbeddingServiceException.invalidVectorDimension(floats.size()));
+        float[] tokenEmbeddings = readFp32Output(response, seqLen);
+        int actual = tokenEmbeddings.length;
+        int expected = seqLen * VECTOR_DIM;
+        if (actual != expected) {
+            throw new EmbeddingServiceException(EmbeddingServiceException.invalidVectorDimension(actual));
         }
 
-        float[] vector = new float[VECTOR_DIM];
-        for (int i = 0; i < VECTOR_DIM; i++) {
-            vector[i] = floats.get(i);
-        }
+        float[] vector = meanPool(tokenEmbeddings, tokens.getAttentionMask(), seqLen);
 
         log.debug("EmbeddingService.embed returning vector [dimensions={}]", vector.length);
         return new EmbeddingResponse(vector);
+    }
+
+    private static ModelInferRequest.InferInputTensor buildIntInput(String name, int seqLen, long[] values) {
+        InferTensorContents.Builder contents = InferTensorContents.newBuilder();
+        List<Long> boxed = new ArrayList<>(values.length);
+        for (long v : values) {
+            boxed.add(v);
+        }
+        contents.addAllInt64Contents(boxed);
+        return ModelInferRequest.InferInputTensor.newBuilder()
+            .setName(name)
+            .setDatatype(INT64)
+            .addShape(1).addShape(seqLen)
+            .setContents(contents)
+            .build();
+    }
+
+    /**
+     * Triton's gRPC server returns FP32 outputs in {@code raw_output_contents} (binary, little-endian)
+     * by default. The typed {@code outputs[i].contents.fp32_contents} list is used only when the server
+     * is configured otherwise. Read whichever channel is populated.
+     */
+    private static float[] readFp32Output(ModelInferResponse response, int seqLen) {
+        if (response.getRawOutputContentsCount() > 0) {
+            ByteString bytes = response.getRawOutputContents(0);
+            int floatCount = bytes.size() / Float.BYTES;
+            float[] out = new float[floatCount];
+            ByteBuffer buf = bytes.asReadOnlyByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
+            for (int i = 0; i < floatCount; i++) {
+                out[i] = buf.getFloat();
+            }
+            return out;
+        }
+        List<Float> typed = response.getOutputs(0).getContents().getFp32ContentsList();
+        float[] out = new float[typed.size()];
+        for (int i = 0; i < typed.size(); i++) {
+            out[i] = typed.get(i);
+        }
+        return out;
+    }
+
+    private static float[] meanPool(float[] tokenEmbeddings, long[] attentionMask, int seqLen) {
+        float[] pooled = new float[VECTOR_DIM];
+        long maskSum = 0;
+        for (int t = 0; t < seqLen; t++) {
+            long m = attentionMask[t];
+            if (m == 0L) {
+                continue;
+            }
+            maskSum += m;
+            int rowOffset = t * VECTOR_DIM;
+            for (int d = 0; d < VECTOR_DIM; d++) {
+                pooled[d] += tokenEmbeddings[rowOffset + d] * m;
+            }
+        }
+        float divisor = (float) Math.max(maskSum, 1L);
+        for (int d = 0; d < VECTOR_DIM; d++) {
+            pooled[d] /= divisor;
+        }
+        return pooled;
     }
 
     private EmbeddingServiceException mapException(StatusRuntimeException e) {

--- a/api/src/main/java/com/moviesearch/service/impl/HuggingFaceQueryTokenizer.java
+++ b/api/src/main/java/com/moviesearch/service/impl/HuggingFaceQueryTokenizer.java
@@ -1,0 +1,73 @@
+package com.moviesearch.service.impl;
+
+import ai.djl.huggingface.tokenizers.Encoding;
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+import com.moviesearch.config.TritonProperties;
+import com.moviesearch.model.TokenizedInput;
+import com.moviesearch.service.QueryTokenizer;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@ConditionalOnProperty(name = "triton.mock", havingValue = "false", matchIfMissing = true)
+public class HuggingFaceQueryTokenizer implements QueryTokenizer {
+
+    private static final Logger log = LoggerFactory.getLogger(HuggingFaceQueryTokenizer.class);
+
+    private final HuggingFaceTokenizer tokenizer;
+    private final int maxLength;
+
+    public HuggingFaceQueryTokenizer(TritonProperties props) {
+        this.maxLength = props.getMaxLength();
+        Path path = Paths.get(props.getTokenizerPath());
+        Map<String, String> options = new HashMap<>();
+        options.put("padding", "max_length");
+        options.put("truncation", "true");
+        options.put("maxLength", String.valueOf(maxLength));
+        try {
+            this.tokenizer = HuggingFaceTokenizer.newInstance(path, options);
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                "Failed to load HuggingFace tokenizer from " + path
+                    + ". Confirm the model-repository tokenizer files are mounted into the api container.", e);
+        }
+        log.info("HuggingFaceQueryTokenizer initialized [tokenizerPath={}, maxLength={}]", path, maxLength);
+    }
+
+    @Override
+    public TokenizedInput tokenize(String text) {
+        Encoding encoding = tokenizer.encode(text);
+        long[] inputIds = padOrTruncate(encoding.getIds(), maxLength);
+        long[] attentionMask = padOrTruncate(encoding.getAttentionMask(), maxLength);
+        long[] typeIdsRaw = encoding.getTypeIds();
+        long[] tokenTypeIds = typeIdsRaw == null
+            ? new long[maxLength]
+            : padOrTruncate(typeIdsRaw, maxLength);
+        return new TokenizedInput(inputIds, attentionMask, tokenTypeIds);
+    }
+
+    private static long[] padOrTruncate(long[] src, int target) {
+        if (src.length == target) {
+            return src;
+        }
+        long[] out = new long[target];
+        System.arraycopy(src, 0, out, 0, Math.min(src.length, target));
+        return out;
+    }
+
+    @PreDestroy
+    void close() {
+        if (tokenizer != null) {
+            tokenizer.close();
+        }
+    }
+}

--- a/api/src/main/java/com/moviesearch/service/impl/MockQueryTokenizer.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockQueryTokenizer.java
@@ -1,0 +1,31 @@
+package com.moviesearch.service.impl;
+
+import com.moviesearch.config.TritonProperties;
+import com.moviesearch.model.TokenizedInput;
+import com.moviesearch.service.QueryTokenizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(name = "triton.mock", havingValue = "true")
+public class MockQueryTokenizer implements QueryTokenizer {
+
+    private final int maxLength;
+
+    public MockQueryTokenizer(TritonProperties props) {
+        this.maxLength = props.getMaxLength();
+    }
+
+    @Override
+    public TokenizedInput tokenize(String text) {
+        long[] inputIds = new long[maxLength];
+        long[] attentionMask = new long[maxLength];
+        long[] tokenTypeIds = new long[maxLength];
+        int filled = Math.min(text.length(), maxLength);
+        for (int i = 0; i < filled; i++) {
+            inputIds[i] = (long) text.charAt(i);
+            attentionMask[i] = 1L;
+        }
+        return new TokenizedInput(inputIds, attentionMask, tokenTypeIds);
+    }
+}

--- a/api/src/test/java/com/moviesearch/EmbeddingServiceIntegrationTest.java
+++ b/api/src/test/java/com/moviesearch/EmbeddingServiceIntegrationTest.java
@@ -3,34 +3,62 @@ package com.moviesearch;
 import com.moviesearch.config.TritonGrpcConfig;
 import com.moviesearch.config.TritonProperties;
 import com.moviesearch.service.EmbeddingService;
+import com.moviesearch.service.QueryTokenizer;
 import com.moviesearch.service.impl.EmbeddingServiceImpl;
+import com.moviesearch.service.impl.HuggingFaceQueryTokenizer;
 import com.moviesearch.service.impl.MockEmbeddingService;
+import com.moviesearch.service.impl.MockQueryTokenizer;
 import inference.GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingStub;
 import io.grpc.ManagedChannel;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class EmbeddingServiceIntegrationTest {
+
+    private static final Path REAL_TOKENIZER_PATH =
+        Paths.get("..", "model-repository", "all-minilm-l6-v2", "1", "tokenizer.json")
+            .toAbsolutePath().normalize();
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withUserConfiguration(
                     TritonGrpcConfig.class,
-                    TritonProperties.class,
                     EmbeddingServiceImpl.class,
-                    MockEmbeddingService.class);
+                    HuggingFaceQueryTokenizer.class,
+                    MockEmbeddingService.class,
+                    MockQueryTokenizer.class)
+            .withBean(TritonProperties.class, () -> {
+                TritonProperties p = new TritonProperties();
+                p.setTokenizerPath(REAL_TOKENIZER_PATH.toString());
+                return p;
+            });
+
+    private void assumeTokenizerAvailable() {
+        assumeTrue(Files.exists(REAL_TOKENIZER_PATH),
+            "Skipping: tokenizer.json not found at " + REAL_TOKENIZER_PATH
+                + ". Run `./start-services.sh --rebuild` (or load-model) to populate it.");
+    }
 
     @Test
     void defaultConfig_embeddingServiceImplIsActive() {
+        assumeTokenizerAvailable();
         contextRunner.run(ctx -> {
             assertThat(ctx).hasSingleBean(EmbeddingService.class);
             assertThat(ctx.getBean(EmbeddingService.class)).isInstanceOf(EmbeddingServiceImpl.class);
+            assertThat(ctx).hasSingleBean(QueryTokenizer.class);
+            assertThat(ctx.getBean(QueryTokenizer.class)).isInstanceOf(HuggingFaceQueryTokenizer.class);
         });
     }
 
     @Test
     void defaultConfig_managedChannelAndStubPresent() {
+        assumeTokenizerAvailable();
         contextRunner.run(ctx -> {
             assertThat(ctx).hasSingleBean(ManagedChannel.class);
             assertThat(ctx).hasSingleBean(GRPCInferenceServiceBlockingStub.class);
@@ -39,6 +67,7 @@ class EmbeddingServiceIntegrationTest {
 
     @Test
     void mockFalse_embeddingServiceImplIsActive() {
+        assumeTokenizerAvailable();
         contextRunner
                 .withPropertyValues("triton.mock=false")
                 .run(ctx -> {
@@ -49,6 +78,7 @@ class EmbeddingServiceIntegrationTest {
 
     @Test
     void mockFalse_managedChannelAndStubPresent() {
+        assumeTokenizerAvailable();
         contextRunner
                 .withPropertyValues("triton.mock=false")
                 .run(ctx -> {
@@ -64,6 +94,8 @@ class EmbeddingServiceIntegrationTest {
                 .run(ctx -> {
                     assertThat(ctx).hasSingleBean(EmbeddingService.class);
                     assertThat(ctx.getBean(EmbeddingService.class)).isInstanceOf(MockEmbeddingService.class);
+                    assertThat(ctx).hasSingleBean(QueryTokenizer.class);
+                    assertThat(ctx.getBean(QueryTokenizer.class)).isInstanceOf(MockQueryTokenizer.class);
                 });
     }
 
@@ -85,6 +117,7 @@ class EmbeddingServiceIntegrationTest {
             assertThat(props.getPort()).isEqualTo(8001);
             assertThat(props.getModelName()).isEqualTo("all-MiniLM-L6-v2");
             assertThat(props.getDeadlineMs()).isEqualTo(5000L);
+            assertThat(props.getMaxLength()).isEqualTo(128);
         });
     }
 }

--- a/api/src/test/java/com/moviesearch/service/impl/EmbeddingServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/EmbeddingServiceImplTest.java
@@ -8,6 +8,8 @@ import com.moviesearch.config.TritonProperties;
 import com.moviesearch.exception.EmbeddingServiceException;
 import com.moviesearch.model.EmbeddingRequest;
 import com.moviesearch.model.EmbeddingResponse;
+import com.moviesearch.model.TokenizedInput;
+import com.moviesearch.service.QueryTokenizer;
 import inference.GRPCInferenceServiceGrpc.GRPCInferenceServiceBlockingStub;
 import inference.Inference.InferTensorContents;
 import inference.Inference.ModelInferRequest;
@@ -17,11 +19,11 @@ import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -34,8 +36,14 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class EmbeddingServiceImplTest {
 
+    private static final int VECTOR_DIM = 384;
+    private static final int SEQ_LEN = 128;
+
     @Mock
     private GRPCInferenceServiceBlockingStub stub;
+
+    @Mock
+    private QueryTokenizer tokenizer;
 
     private TritonProperties props;
     private EmbeddingServiceImpl service;
@@ -43,18 +51,56 @@ class EmbeddingServiceImplTest {
     @BeforeEach
     void setUp() {
         props = new TritonProperties();
-        service = new EmbeddingServiceImpl(stub, props);
+        service = new EmbeddingServiceImpl(stub, tokenizer, props);
     }
 
-    private ModelInferResponse buildResponse(int dims) {
-        InferTensorContents.Builder contents = InferTensorContents.newBuilder();
-        for (int i = 0; i < dims; i++) {
-            contents.addFp32Contents(0.1f * i);
+    private TokenizedInput tokenizedInput(int activeTokens) {
+        long[] inputIds = new long[SEQ_LEN];
+        long[] mask = new long[SEQ_LEN];
+        long[] types = new long[SEQ_LEN];
+        for (int i = 0; i < activeTokens; i++) {
+            inputIds[i] = 100L + i;
+            mask[i] = 1L;
         }
+        return new TokenizedInput(inputIds, mask, types);
+    }
+
+    /** Constant-valued token embeddings — pooled value should equal that constant for any mask. */
+    private ModelInferResponse buildConstantResponse(float value) {
+        InferTensorContents.Builder contents = InferTensorContents.newBuilder();
+        for (int t = 0; t < SEQ_LEN; t++) {
+            for (int d = 0; d < VECTOR_DIM; d++) {
+                contents.addFp32Contents(value);
+            }
+        }
+        return wrap(contents);
+    }
+
+    /** Per-token embeddings where token t has every dim set to (t+1)f. Pooled value depends on mask. */
+    private ModelInferResponse buildPerTokenResponse() {
+        InferTensorContents.Builder contents = InferTensorContents.newBuilder();
+        for (int t = 0; t < SEQ_LEN; t++) {
+            float v = (float) (t + 1);
+            for (int d = 0; d < VECTOR_DIM; d++) {
+                contents.addFp32Contents(v);
+            }
+        }
+        return wrap(contents);
+    }
+
+    private ModelInferResponse buildResponseOfSize(int totalFloats) {
+        InferTensorContents.Builder contents = InferTensorContents.newBuilder();
+        for (int i = 0; i < totalFloats; i++) {
+            contents.addFp32Contents(0.0f);
+        }
+        return wrap(contents);
+    }
+
+    private ModelInferResponse wrap(InferTensorContents.Builder contents) {
         ModelInferResponse.InferOutputTensor output = ModelInferResponse.InferOutputTensor.newBuilder()
-            .setName("sentence_embedding")
+            .setName("token_embeddings")
             .setDatatype("FP32")
-            .addShape(1).addShape(dims)
+            .addShape(1).addShape(SEQ_LEN).addShape(VECTOR_DIM)
             .setContents(contents)
             .build();
         return ModelInferResponse.newBuilder().addOutputs(output).build();
@@ -73,49 +119,78 @@ class EmbeddingServiceImplTest {
 
     @Test
     void embed_returnsCorrectDimensions() {
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
         when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
-        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildConstantResponse(1.0f));
 
         EmbeddingResponse response = service.embed(new EmbeddingRequest("hello world"));
 
-        assertThat(response.getVector()).hasSize(384);
+        assertThat(response.getVector()).hasSize(VECTOR_DIM);
     }
 
     @Test
-    void embed_vectorValuesMatchResponse() {
+    void embed_constantTokenEmbeddings_pooledMatchesConstant() {
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(5));
         when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
-        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildConstantResponse(0.5f));
 
-        float[] vector = service.embed(new EmbeddingRequest("hello world")).getVector();
+        float[] vector = service.embed(new EmbeddingRequest("hello")).getVector();
 
-        assertThat(vector[0]).isEqualTo(0.0f);
-        assertThat(vector[1]).isEqualTo(0.1f);
-        assertThat(vector[2]).isEqualTo(0.2f);
-    }
-
-    @Test
-    void embed_logEntryMessage() {
-        ListAppender<ILoggingEvent> appender = attachLogAppender(EmbeddingServiceImpl.class);
-        Logger logger = (Logger) LoggerFactory.getLogger(EmbeddingServiceImpl.class);
-        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
-        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
-
-        try {
-            service.embed(new EmbeddingRequest("hello world"));
-            List<String> messages = appender.list.stream()
-                .map(ILoggingEvent::getFormattedMessage).toList();
-            assertThat(messages).contains("EmbeddingService.embed called [text='hello world']");
-        } finally {
-            logger.detachAppender(appender);
+        for (float v : vector) {
+            assertThat(v).isEqualTo(0.5f);
         }
+    }
+
+    @Test
+    void embed_meanPoolingHonorsAttentionMask() {
+        // mask covers tokens 0..2 (values 1, 2, 3). Tokens 3..127 have value 4..128 but mask=0.
+        // Expected mean: (1+2+3)/3 = 2.0 across all 384 dims.
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildPerTokenResponse());
+
+        float[] vector = service.embed(new EmbeddingRequest("hello")).getVector();
+
+        for (float v : vector) {
+            assertThat(v).isEqualTo(2.0f);
+        }
+    }
+
+    @Test
+    void embed_buildsRequestWithThreeInt64InputsAndCorrectShapes() {
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildConstantResponse(0.0f));
+
+        ArgumentCaptor<ModelInferRequest> captor = ArgumentCaptor.forClass(ModelInferRequest.class);
+        service.embed(new EmbeddingRequest("hello"));
+
+        org.mockito.Mockito.verify(stub).modelInfer(captor.capture());
+        ModelInferRequest req = captor.getValue();
+        assertThat(req.getModelName()).isEqualTo(props.getModelName());
+        assertThat(req.getInputsCount()).isEqualTo(3);
+
+        List<String> inputNames = req.getInputsList().stream()
+            .map(ModelInferRequest.InferInputTensor::getName).toList();
+        assertThat(inputNames).containsExactly("input_ids", "attention_mask", "token_type_ids");
+
+        for (ModelInferRequest.InferInputTensor t : req.getInputsList()) {
+            assertThat(t.getDatatype()).isEqualTo("INT64");
+            assertThat(t.getShapeList()).containsExactly(1L, (long) SEQ_LEN);
+            assertThat(t.getContents().getInt64ContentsCount()).isEqualTo(SEQ_LEN);
+        }
+
+        assertThat(req.getOutputsCount()).isEqualTo(1);
+        assertThat(req.getOutputs(0).getName()).isEqualTo("token_embeddings");
     }
 
     @Test
     void embed_logExitMessage() {
         ListAppender<ILoggingEvent> appender = attachLogAppender(EmbeddingServiceImpl.class);
         Logger logger = (Logger) LoggerFactory.getLogger(EmbeddingServiceImpl.class);
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
         when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
-        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildConstantResponse(0.0f));
 
         try {
             service.embed(new EmbeddingRequest("hello world"));
@@ -128,11 +203,30 @@ class EmbeddingServiceImplTest {
     }
 
     @Test
+    void embed_logEntryMessage() {
+        ListAppender<ILoggingEvent> appender = attachLogAppender(EmbeddingServiceImpl.class);
+        Logger logger = (Logger) LoggerFactory.getLogger(EmbeddingServiceImpl.class);
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
+        when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildConstantResponse(0.0f));
+
+        try {
+            service.embed(new EmbeddingRequest("hello world"));
+            List<String> messages = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage).toList();
+            assertThat(messages).contains("EmbeddingService.embed called [text='hello world']");
+        } finally {
+            logger.detachAppender(appender);
+        }
+    }
+
+    @Test
     void embed_longTextTruncatedInLog() {
         ListAppender<ILoggingEvent> appender = attachLogAppender(EmbeddingServiceImpl.class);
         Logger logger = (Logger) LoggerFactory.getLogger(EmbeddingServiceImpl.class);
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
         when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
-        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(384));
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildConstantResponse(0.0f));
 
         String longText = "a".repeat(100);
         try {
@@ -150,6 +244,7 @@ class EmbeddingServiceImplTest {
 
     @Test
     void embed_grpcUnavailable_throwsConnectionRefused() {
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
         when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
         when(stub.modelInfer(any(ModelInferRequest.class)))
             .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE));
@@ -161,6 +256,7 @@ class EmbeddingServiceImplTest {
 
     @Test
     void embed_grpcDeadlineExceeded_throwsConnectionRefused() {
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
         when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
         when(stub.modelInfer(any(ModelInferRequest.class)))
             .thenThrow(new StatusRuntimeException(Status.DEADLINE_EXCEEDED));
@@ -172,6 +268,7 @@ class EmbeddingServiceImplTest {
 
     @Test
     void embed_grpcInvalidArgument_throwsInvalidRequest() {
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
         when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
         when(stub.modelInfer(any(ModelInferRequest.class)))
             .thenThrow(new StatusRuntimeException(Status.INVALID_ARGUMENT));
@@ -183,6 +280,7 @@ class EmbeddingServiceImplTest {
 
     @Test
     void embed_grpcUnknownStatus_throwsConnectionRefused() {
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
         when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
         when(stub.modelInfer(any(ModelInferRequest.class)))
             .thenThrow(new StatusRuntimeException(Status.INTERNAL));
@@ -192,12 +290,13 @@ class EmbeddingServiceImplTest {
             .hasMessage(EmbeddingServiceException.CONNECTION_REFUSED);
     }
 
-    // --- Invalid vector dimension ---
+    // --- Invalid response size ---
 
     @Test
-    void embed_wrongDimension_throwsException() {
+    void embed_unexpectedResponseSize_throwsException() {
+        when(tokenizer.tokenize(any())).thenReturn(tokenizedInput(3));
         when(stub.withDeadlineAfter(anyLong(), any(TimeUnit.class))).thenReturn(stub);
-        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponse(100));
+        when(stub.modelInfer(any(ModelInferRequest.class))).thenReturn(buildResponseOfSize(100));
 
         assertThatThrownBy(() -> service.embed(new EmbeddingRequest("hello")))
             .isInstanceOf(EmbeddingServiceException.class)

--- a/api/src/test/java/com/moviesearch/service/impl/MockQueryTokenizerTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/MockQueryTokenizerTest.java
@@ -1,0 +1,66 @@
+package com.moviesearch.service.impl;
+
+import com.moviesearch.config.TritonProperties;
+import com.moviesearch.model.TokenizedInput;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MockQueryTokenizerTest {
+
+    @Test
+    void tokenize_returnsArraysOfMaxLength() {
+        TritonProperties props = new TritonProperties();
+        props.setMaxLength(16);
+        MockQueryTokenizer tokenizer = new MockQueryTokenizer(props);
+
+        TokenizedInput out = tokenizer.tokenize("hello");
+
+        assertThat(out.getInputIds()).hasSize(16);
+        assertThat(out.getAttentionMask()).hasSize(16);
+        assertThat(out.getTokenTypeIds()).hasSize(16);
+    }
+
+    @Test
+    void tokenize_attentionMaskCoversTextOnly() {
+        TritonProperties props = new TritonProperties();
+        props.setMaxLength(16);
+        MockQueryTokenizer tokenizer = new MockQueryTokenizer(props);
+
+        long[] mask = tokenizer.tokenize("hello").getAttentionMask();
+
+        for (int i = 0; i < 5; i++) {
+            assertThat(mask[i]).isEqualTo(1L);
+        }
+        for (int i = 5; i < 16; i++) {
+            assertThat(mask[i]).isEqualTo(0L);
+        }
+    }
+
+    @Test
+    void tokenize_truncatesTextLongerThanMaxLength() {
+        TritonProperties props = new TritonProperties();
+        props.setMaxLength(4);
+        MockQueryTokenizer tokenizer = new MockQueryTokenizer(props);
+
+        TokenizedInput out = tokenizer.tokenize("hello world");
+
+        assertThat(out.length()).isEqualTo(4);
+        for (long m : out.getAttentionMask()) {
+            assertThat(m).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void tokenize_tokenTypeIdsAlwaysZero() {
+        TritonProperties props = new TritonProperties();
+        props.setMaxLength(16);
+        MockQueryTokenizer tokenizer = new MockQueryTokenizer(props);
+
+        long[] types = tokenizer.tokenize("hello").getTokenTypeIds();
+
+        for (long t : types) {
+            assertThat(t).isEqualTo(0L);
+        }
+    }
+}

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -1,0 +1,32 @@
+triton:
+  host: ${TRITON_HOST:localhost}
+  port: 8001
+  model-name: all-minilm-l6-v2
+  deadline-ms: 5000
+  max-length: 128
+  tokenizer-path: ${user.dir}/../model-repository/all-minilm-l6-v2/1/tokenizer.json
+
+qdrant:
+  base-url: ${QDRANT_BASE_URL:http://localhost:6333}
+  mock: false
+
+search:
+  default-limit: 10
+
+autocomplete:
+  limit: 3
+
+tmdb:
+  poster-base-url: https://image.tmdb.org/t/p/w200
+  api-key: ${TMDB_API_KEY:}
+
+dataset:
+  corpus-url: http://www.cs.cmu.edu/~ark/personas/data/MovieSummaries.tar.gz
+  data-dir: data/corpus
+
+model:
+  script-dir: ../pipeline
+  model-dir: ../model-repository
+
+project:
+  root: .

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,7 +3,15 @@
 # making it impractical for standard GitHub Actions runners. The gRPC channel
 # in TritonGrpcConfig.java is lazy — no connection to port 8001 is made at
 # startup — so the stub only needs to handle the HTTP healthcheck on port 8000.
+#
+# The api service is also flipped into triton.mock=true so HuggingFaceQueryTokenizer
+# doesn't try to load tokenizer.json at startup. Those artifacts are produced by
+# load-model (skipped in CI to keep runs fast) and are bind-mounted into the
+# container at /app/tokenizer in normal operation.
 services:
+  api:
+    environment:
+      - TRITON_MOCK=true
   triton:
     image: python:3.12-alpine
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     environment:
       - TRITON_HOST=triton
       - QDRANT_BASE_URL=http://qdrant:6333
+    volumes:
+      - ./model-repository/all-minilm-l6-v2/1:/app/tokenizer:ro
     ports:
       - "8080:8080"
     depends_on:

--- a/start-services.sh
+++ b/start-services.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if docker compose version &>/dev/null 2>&1; then
+  DC="docker compose"
+elif docker-compose version &>/dev/null 2>&1; then
+  DC="docker-compose"
+else
+  echo "Error: neither 'docker compose' nor 'docker-compose' is available" >&2
+  exit 1
+fi
+
 REBUILD=false
 
 for arg in "$@"; do
@@ -52,20 +61,23 @@ wait_for_healthy() {
 }
 
 if [[ "$REBUILD" == "true" ]]; then
-  docker compose down --rmi local -v
+  $DC down --rmi local -v
 
-  rm -rf data/raw/ data/embeddings/ \
+  # Files written by containers may be owned by root or container UIDs that
+  # the host user cannot remove directly. Delete them from inside a container.
+  docker run --rm -v "$(pwd):/work" -w /work alpine rm -rf \
+    data/raw data/embeddings \
     model-repository/all-minilm-l6-v2/1/model.onnx \
     model-repository/all-minilm-l6-v2/1/tokenizer.json \
     model-repository/all-minilm-l6-v2/1/tokenizer_config.json \
     model-repository/all-minilm-l6-v2/1/vocab.txt \
     model-repository/all-minilm-l6-v2/1/special_tokens_map.json
 
-  docker compose run --rm load-model || (echo "[rebuild] load-model phase failed — aborting" && exit 1)
-  docker compose up -d || (echo "[rebuild] services-up phase failed — aborting" && exit 1)
-  docker compose run --rm load-data || (echo "[rebuild] load-data phase failed — aborting" && exit 1)
+  $DC run --rm load-model || (echo "[rebuild] load-model phase failed — aborting" && exit 1)
+  $DC up -d || (echo "[rebuild] services-up phase failed — aborting" && exit 1)
+  $DC run --rm load-data || (echo "[rebuild] load-data phase failed — aborting" && exit 1)
 else
-  docker compose up -d
+  $DC up -d
 fi
 
 wait_for_healthy || exit 1


### PR DESCRIPTION
## Summary
- End-to-end walking through `docs/executive-guide.html` revealed the API↔Triton integration was missing — `EmbeddingServiceImpl` spoke a fictional single-`TEXT`-input contract while the deployed ONNX model exposes `input_ids` / `attention_mask` / `token_type_ids` (INT64) and `token_embeddings` (FP32) with host-side mean pooling. Fixed by adding query-side tokenization in the API.
- Two `start-services.sh` issues were also blocking the walkthrough on this host: hardcoded `docker compose` (v2-only) and `rm -rf` of root-owned data. Both fixed.

## API change (Path 2 — Java-side tokenization, no Triton model changes)
- New `QueryTokenizer` interface + `TokenizedInput` model.
- `HuggingFaceQueryTokenizer` uses DJL `ai.djl.huggingface:tokenizers:0.27.0` and loads the same `tokenizer.json` the pipeline produces (`max_length=128`, padding+truncation).
- `MockQueryTokenizer` for the existing `triton.mock=true` profile.
- `TritonProperties` gains `maxLength` and `tokenizerPath`.
- `docker-compose.yml`: bind-mount `./model-repository/all-minilm-l6-v2/1:/app/tokenizer:ro` on the api service so the tokenizer files produced by `load-model` are available at runtime.
- `EmbeddingServiceImpl` rewrite: tokenize → 3 INT64 tensors `[1,L]` → request `token_embeddings` → read FP32 from `raw_output_contents` (Triton's default binary channel) with a `contents.fp32_contents` fallback → mask-aware mean pool. No L2 normalize (matches `pipeline/03_embed_corpus.py`).
- All gRPC status → 503/`EmbeddingServiceException` mapping is preserved.

## `start-services.sh` fixes
- Autodetect `docker compose` v2 vs `docker-compose` v1 (mirrors the pattern already in `stop-services.sh`).
- Run the pre-rebuild cleanup `rm -rf` inside an `alpine` container so files left root-owned by previous container runs can be deleted.

## Tests
- `EmbeddingServiceImplTest` rewritten with a mocked `QueryTokenizer`. Adds explicit assertions on request shape/datatypes/input names, mask-aware mean pooling math, response-size mismatch, and keeps the prior gRPC status mapping coverage.
- New `MockQueryTokenizerTest`.
- `EmbeddingServiceIntegrationTest` updated to wire both tokenizer impls and inject a `TritonProperties` whose `tokenizerPath` points at the workspace copy.
- `api/src/test/resources/application.yml` added so `@SpringBootTest` contexts find the tokenizer at the workspace path.
- `Tests run: 212, Failures: 0, Errors: 0, Skipped: 0`.

## Test plan
- [ ] `./mvnw -f api/pom.xml test` — green.
- [ ] `./start-services.sh --rebuild` from a clean state — completes without compose-v2 or permission errors.
- [ ] http://localhost:6333/dashboard → `movies` collection points > 0, status Green, vectors populated.
- [ ] Swagger UI `GET /api/search?q=sci-fi%20space%20adventure` → HTTP 200 with relevant sci-fi/space results.
- [ ] http://localhost:8080 → search box returns relevant results for several semantic queries.
- [ ] Stop Triton, hit `/api/search` → 503 with mapped error (no stack); restart Triton → search works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)