### PR TITLE
Ignore local scripts and draft specs in git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ pipeline/*.egg-info
 *.DS_Store
 prompt.txt
 .claude/settings.local.json
+
+# Local workflow helpers and unpublished spec drafts
+scripts/
+docs/specs/feature-3/
+docs/specs/feature-4/
+docs/specs/feature-5/*.md
+docs/specs/feature-6/*.md


### PR DESCRIPTION
## Summary
- `scripts/` (`check-blockers.sh`, `worktree-remove.sh`) are local workflow helpers — not part of the build.
- `docs/specs/feature-3/`, `docs/specs/feature-4/` and the `.md` files under `docs/specs/feature-5/` and `docs/specs/feature-6/` are draft spec sources that haven't gone through the normal per-feature PR. The rendered `.html` siblings for feature-5/6 are already committed; this just stops the markdown drafts from cluttering `git status`.
- No tracked files are removed; `.gitignore` rules don't affect already-tracked content.

## Test plan
- [ ] `git status` is clean on `main` after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)