### PR TITLE
Specs: Multi-vector ingestion and mean-pooled search

### DIFF
--- a/docs/specs/feature-267/EmbedCorpusPipeline.md
+++ b/docs/specs/feature-267/EmbedCorpusPipeline.md
@@ -1,0 +1,103 @@
+# EmbedCorpusPipeline Spec
+
+**Feature:** #267 — Multi-vector ingestion and mean-pooled search for full movie summaries
+**Component:** `EmbedCorpusPipeline` (`pipeline/03_embed_corpus.py`)
+
+## Overview
+
+`EmbedCorpusPipeline` (`03_embed_corpus.py`) is updated to replace the 300-char truncation with full-summary chunking. `join_data` now produces a flat list of per-chunk records — one entry per chunk, with all movie-level fields (`movie_id`, `title`, `release_year`, `genres`) plus `chunk_text` (the chunk) and `full_summary` (the complete uncapped summary) on every record. `main` drives `SummaryChunker` per movie, embeds every chunk record independently, and writes the resulting flat `embeddings.npy` and `metadata.json`. Movies with empty summaries are silently skipped (produce zero records). The existing idempotency check (skip if both output files exist) is preserved.
+
+## Data Contract
+
+### Input files (unchanged paths)
+| File | Format | Notes |
+|------|--------|-------|
+| `data/raw/movie.metadata.tsv` | TSV, 9 columns | Column 0: movie_id, 2: title, 3: release_date, 8: genres JSON |
+| `data/raw/plot_summaries.txt` | TSV, 2 columns | Column 0: movie_id, 1: full summary text |
+
+### Per-chunk record (element of `metadata.json`)
+| Field | Type | Description | Behavior |
+|-------|------|-------------|----------|
+| `movie_id` | `str` | CMU movie identifier | Repeated on every chunk for the same movie |
+| `title` | `str` | Movie title | Repeated on every chunk |
+| `release_year` | `int \| null` | Parsed from release_date | Repeated on every chunk |
+| `genres` | `list[str]` | Genre names | Repeated on every chunk |
+| `chunk_text` | `str` | Decoded text of this chunk | Unique per record |
+| `full_summary` | `str` | Complete uncapped summary | Repeated on every chunk; same as the raw summary text from the source file |
+
+### Output files
+| File | Format | Notes |
+|------|--------|-------|
+| `data/embeddings/embeddings.npy` | `float32` array `[N_chunks, 384]` | Row i corresponds to `metadata.json[i]` |
+| `data/embeddings/metadata.json` | JSON array of chunk records | One element per chunk (not per movie) |
+
+### CLI flags (new/changed)
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--window-size` | `512` | Token window size passed to SummaryChunker |
+| `--overlap` | `64` | Token overlap passed to SummaryChunker |
+| `--max-chunks` | `10` | Chunk cap passed to SummaryChunker |
+| `--batch-size` | `64` | Embedding batch size (unchanged) |
+| `--triton-host` | `localhost` | Unchanged |
+| `--triton-port` | `8001` | Unchanged |
+
+## Dependencies
+
+| Dependency | Interface / Type | Injected As |
+|------------|-----------------|-------------|
+| `SummaryChunker` | `chunk_summary(text, tokenizer, window_size, overlap, max_chunks) -> list[str]` | Direct call |
+| `AutoTokenizer` | HuggingFace tokenizer | Constructed in `main` via `AutoTokenizer.from_pretrained` |
+| `_infer_batch` | `(grpcclient, client, input_ids, attention_mask, token_type_ids) -> np.ndarray` | Direct call (monkeypatched in tests) |
+| Triton gRPC client | `grpcclient.InferenceServerClient` | Constructed in `main` |
+
+### Dependency Mock Behaviors
+
+#### SummaryChunker (`chunk_summary`)
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| Happy path | Returns list of 1–`max_chunks` strings | Normal multi-chunk movie |
+| Empty summary | Returns `[]` | Movie silently skipped |
+| Single chunk | Returns `["<text>"]` | Short movie; one point in Qdrant |
+
+#### `_infer_batch`
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| Happy path | Returns `np.ones((B, 384), dtype="float32")` | Used in existing tests; same pattern |
+| Triton unavailable | Raises `InferenceServerException` | Not in scope of unit tests (integration concern) |
+
+**Mock data structures:**
+```json
+// metadata.json output — 2 movies, movie "111" has 2 chunks, movie "222" has 1 chunk
+[
+  {"movie_id": "111", "title": "Cast Away", "release_year": 2000, "genres": ["Drama"],
+   "chunk_text": "A FedEx executive crash-lands on an island.", "full_summary": "A FedEx executive crash-lands on an island. He must survive alone for years."},
+  {"movie_id": "111", "title": "Cast Away", "release_year": 2000, "genres": ["Drama"],
+   "chunk_text": "He must survive alone for years.", "full_summary": "A FedEx executive crash-lands on an island. He must survive alone for years."},
+  {"movie_id": "222", "title": "Alien", "release_year": 1979, "genres": ["Sci-Fi"],
+   "chunk_text": "In space, no one can hear you scream.", "full_summary": "In space, no one can hear you scream."}
+]
+```
+
+## Edge Cases
+
+| # | Input | Expected Output | Description | Mock Setup |
+|---|-------|----------------|-------------|------------|
+| 1 | Movie with empty summary | Movie absent from metadata.json and embeddings.npy | Silent skip | `chunk_summary` returns `[]` |
+| 2 | All movies have empty summaries | Empty metadata.json, 0-row embeddings.npy | Degenerate but valid | All `chunk_summary` calls return `[]` |
+| 3 | Movie with summary fitting one chunk | One record for that movie in metadata.json | No truncation | `chunk_summary` returns one-element list |
+| 4 | Both output files already exist | `sys.exit(0)` without loading data | Idempotency preserved | No mocks needed |
+| 5 | `full_summary` field | Same value on all chunk records for a movie | Not truncated by chunk cap | `chunk_summary` receives full text; `full_summary` written from raw summary |
+
+## Unit Test Checklist
+
+- [ ] Happy path: `join_data` with 2 movies (3 and 1 chunks) returns 4 flat records
+- [ ] Each record contains `movie_id`, `title`, `release_year`, `genres`, `chunk_text`, `full_summary`
+- [ ] `full_summary` on all records for a movie equals the raw summary string (not capped)
+- [ ] Movie with empty summary is absent from `join_data` output
+- [ ] `main` writes `embeddings.npy` with shape `[N_chunks, 384]` where N_chunks equals total chunk records
+- [ ] `main` writes `metadata.json` with one element per chunk record
+- [ ] Row i of `embeddings.npy` corresponds to record i of `metadata.json` (same movie_id at matching index)
+- [ ] Idempotency: `main` exits 0 without calling `_infer_batch` when output files already exist
+- [ ] `--max-chunks`, `--window-size`, `--overlap` CLI flags are accepted and forwarded to `chunk_summary`

--- a/docs/specs/feature-267/IngestQdrantPipeline.md
+++ b/docs/specs/feature-267/IngestQdrantPipeline.md
@@ -1,0 +1,88 @@
+# IngestQdrantPipeline Spec
+
+**Feature:** #267 — Multi-vector ingestion and mean-pooled search for full movie summaries
+**Component:** `IngestQdrantPipeline` (`pipeline/04_ingest_qdrant.py`)
+
+## Overview
+
+`IngestQdrantPipeline` (`04_ingest_qdrant.py`) is updated to consume the flat multi-chunk metadata format produced by `EmbedCorpusPipeline`. `build_points` keeps the same `(embeddings, metadata)` signature — each metadata record now corresponds to one chunk and carries `chunk_text`, `full_summary`, and `movie_id` instead of `summary_snippet`. Point IDs remain global sequential integers (row index into the flat array). The `setup_collection` call and upsert loop are unchanged; only the payload field set changes.
+
+## Data Contract
+
+### `build_points(embeddings, metadata) -> list[PointStruct]`
+
+| Parameter | Type | Description | Behavior |
+|-----------|------|-------------|----------|
+| `embeddings` | `np.ndarray[float32, (N, 384)]` | One row per chunk | Row i must correspond to `metadata[i]` |
+| `metadata` | `list[dict]` | Flat chunk records from `metadata.json` | Each dict must have the fields below |
+
+### Payload fields written per point
+
+| Field | Type | Source | Notes |
+|-------|------|--------|-------|
+| `movie_id` | `str` | `metadata[i]["movie_id"]` | Used by API to group chunks |
+| `title` | `str` | `metadata[i]["title"]` | |
+| `release_year` | `int \| null` | `metadata[i]["release_year"]` | |
+| `genres` | `list[str]` | `metadata[i]["genres"]` | |
+| `chunk_text` | `str` | `metadata[i]["chunk_text"]` | Replaces `summary_snippet` |
+| `full_summary` | `str` | `metadata[i]["full_summary"]` | New field |
+| `thumbnail_url` | `null` | Hardcoded | Enriched later by step 05 |
+
+### Point ID scheme
+- ID = row index `i` (integer, 0-based, global across all chunks)
+- With N total chunk records, IDs are `0 .. N-1`
+
+## Dependencies
+
+| Dependency | Interface / Type | Injected As |
+|------------|-----------------|-------------|
+| `qdrant_client.QdrantClient` | Qdrant Python client | Constructed in `main` |
+| `qdrant_client.http.models.PointStruct` | Data class | Imported |
+
+### Dependency Mock Behaviors
+
+#### QdrantClient
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| Happy path | `recreate_collection` and `upsert` both succeed silently | Normal operation |
+| Qdrant unreachable | `upsert` raises `Exception` | Not in scope of unit tests |
+
+**Mock data structures:**
+```json
+// Sample metadata input (2 chunks for movie 111, 1 for movie 222)
+[
+  {"movie_id": "111", "title": "Cast Away", "release_year": 2000, "genres": ["Drama"],
+   "chunk_text": "A FedEx executive crash-lands.", "full_summary": "A FedEx executive crash-lands. He survives."},
+  {"movie_id": "111", "title": "Cast Away", "release_year": 2000, "genres": ["Drama"],
+   "chunk_text": "He survives.", "full_summary": "A FedEx executive crash-lands. He survives."},
+  {"movie_id": "222", "title": "Alien", "release_year": 1979, "genres": ["Sci-Fi"],
+   "chunk_text": "In space no one hears you.", "full_summary": "In space no one hears you."}
+]
+
+// Expected PointStruct for record 0:
+// id=0, vector=[...384 floats...], payload={movie_id:"111", title:"Cast Away",
+//   release_year:2000, genres:["Drama"], chunk_text:"A FedEx executive crash-lands.",
+//   full_summary:"A FedEx executive crash-lands. He survives.", thumbnail_url:null}
+```
+
+## Edge Cases
+
+| # | Input | Expected Output | Description | Mock Setup |
+|---|-------|----------------|-------------|------------|
+| 1 | Single-chunk metadata (1 record) | 1 PointStruct with id=0 | Minimum valid case | N/A |
+| 2 | Two records for same movie_id | 2 PointStructs with ids 0, 1 | Multiple chunks per movie are independent points | N/A |
+| 3 | `thumbnail_url` not in metadata dict | Payload sets `thumbnail_url=None` | Consistent with existing behavior | N/A |
+| 4 | `recreate_collection` called before `upsert` | `recreate_collection` call index < `upsert` call index | Collection must be reset before inserting | Check `mock_client.method_calls` order |
+
+## Unit Test Checklist
+
+- [ ] `build_points` returns one `PointStruct` per metadata record
+- [ ] IDs are `0, 1, 2, ...` matching record index
+- [ ] Payload includes `chunk_text` and `full_summary` from the metadata record
+- [ ] Payload does **not** include `summary_snippet`
+- [ ] Payload includes `movie_id`
+- [ ] `thumbnail_url` is `None` in the payload
+- [ ] `setup_collection` is called before the first `upsert` in `main`
+- [ ] All points are upserted across batches (total count equals len(metadata))
+- [ ] Two records with the same `movie_id` produce two independent points with different IDs

--- a/docs/specs/feature-267/SummaryChunker.md
+++ b/docs/specs/feature-267/SummaryChunker.md
@@ -1,0 +1,75 @@
+# SummaryChunker Spec
+
+**Feature:** #267 — Multi-vector ingestion and mean-pooled search for full movie summaries
+**Component:** `SummaryChunker` (`pipeline/03_embed_corpus.py`)
+
+## Overview
+
+`SummaryChunker` is a pure function module added to `03_embed_corpus.py` that splits a full movie summary string into overlapping fixed-token windows and applies a configurable chunk cap. It accepts a pre-initialized HuggingFace tokenizer so that token boundaries match exactly what the embedding model sees. An empty or whitespace-only summary produces an empty list; the caller is responsible for skipping that movie.
+
+## Data Contract
+
+| Property | Type | Description | Behavior |
+|----------|------|-------------|----------|
+| `text` | `str` | Full summary text to chunk | May be empty string; whitespace-only treated as empty |
+| `tokenizer` | `AutoTokenizer` | Pre-initialized HuggingFace tokenizer | Must be the same tokenizer used for embedding |
+| `window_size` | `int` | Token count per chunk | Default 512; must be > 0 |
+| `overlap` | `int` | Token overlap between consecutive windows | Default 64; must be < window_size |
+| `max_chunks` | `int` | Maximum number of chunks to return | Default 10; must be > 0 |
+| **return** | `list[str]` | Decoded chunk strings | Empty list if text is empty/whitespace; at most `max_chunks` entries |
+
+## Dependencies
+
+| Dependency | Interface / Type | Injected As |
+|------------|-----------------|-------------|
+| `tokenizer` | `transformers.AutoTokenizer` instance | Parameter |
+
+### Dependency Mock Behaviors
+
+#### tokenizer
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| Happy path | `tokenizer(text, add_special_tokens=False)["input_ids"]` returns list of ints | Normal operation |
+| Short text (fits in one window) | Returns fewer tokens than `window_size` | Produces exactly one chunk |
+| Empty / whitespace text | Early-exit before calling tokenizer | Tokenizer is never called |
+
+**Mock data structures:**
+```json
+// Happy path — long summary producing 3 chunks (window=10, overlap=2, cap=10)
+// Token IDs: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]
+// Chunk 0: tokens [1..10] → decoded "first ten tokens"
+// Chunk 1: tokens [9..18] → decoded "overlapping middle"
+// Chunk 2: tokens [17..20] → decoded "final tail"
+
+// Short text — single chunk
+// Token IDs: [1,2,3] → one chunk decoded as "short summary"
+
+// Empty string
+// Returns []
+```
+
+## Edge Cases
+
+| # | Input | Expected Output | Description | Mock Setup |
+|---|-------|----------------|-------------|------------|
+| 1 | `text=""` | `[]` | Empty string produces no chunks | Tokenizer not called |
+| 2 | `text="   "` | `[]` | Whitespace-only treated as empty | Tokenizer not called |
+| 3 | Text that tokenizes to ≤ `window_size` tokens | `["<full text decoded>"]` | Single chunk, no truncation | Tokenizer returns short ID list |
+| 4 | Text that tokenizes to exactly `window_size` tokens | `["<full text decoded>"]` | Boundary: exactly fills one window | Tokenizer returns ID list of length == window_size |
+| 5 | Text producing > `max_chunks` chunks | List of exactly `max_chunks` strings | Cap is enforced; later chunks discarded | Tokenizer returns long ID list |
+| 6 | `overlap` ≥ `window_size` | `ValueError` raised | Invalid configuration | N/A |
+| 7 | `max_chunks` < 1 | `ValueError` raised | Invalid configuration | N/A |
+
+## Unit Test Checklist
+
+- [ ] Happy path: 3-chunk summary returns 3 decoded strings with correct token boundaries
+- [ ] Empty string returns `[]` without calling tokenizer
+- [ ] Whitespace-only string returns `[]` without calling tokenizer
+- [ ] Text fitting in one window returns list of length 1
+- [ ] Text exactly filling one window returns list of length 1
+- [ ] Text producing 15 chunks with `max_chunks=10` returns exactly 10 strings
+- [ ] Overlap is applied: second chunk starts `window_size - overlap` tokens into the first chunk's token sequence
+- [ ] `overlap >= window_size` raises `ValueError`
+- [ ] `max_chunks < 1` raises `ValueError`
+- [ ] Returned strings are decoded text (not token IDs)

--- a/docs/specs/feature-267/VectorSearchServiceImpl.md
+++ b/docs/specs/feature-267/VectorSearchServiceImpl.md
@@ -1,0 +1,157 @@
+# VectorSearchServiceImpl Spec
+
+**Feature:** #267 — Multi-vector ingestion and mean-pooled search for full movie summaries
+**Component:** `VectorSearchServiceImpl` (`api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java`)
+
+## Overview
+
+`VectorSearchServiceImpl` is updated to support multi-chunk Qdrant results. Instead of requesting `limit` results and mapping 1:1, it requests `limit × oversamplingFactor` chunks, groups them by `movie_id`, computes each movie's score as the arithmetic mean of all its matching chunk scores, and returns up to `limit` distinct movies sorted descending by mean score. The highest-scoring chunk text for each movie is returned as `matchingSegment`; the `full_summary` payload field populates `summarySnippet`. Chunks with a null or missing `movie_id` are silently skipped. The oversampling factor is read from `QdrantProperties.oversamplingFactor` (default 20). `MovieResult` gains a new `matchingSegment` field. `MockVectorSearchService` is updated to populate `matchingSegment` with a hardcoded excerpt per result.
+
+**Backwards compatibility:** this component is designed to be deployed before the pipeline is re-run against the new schema. When Qdrant still holds old-schema data (one point per movie, `summary_snippet` present, `chunk_text`/`full_summary` absent), the service must degrade gracefully: grouping by `movie_id` is a no-op (one chunk per movie), the mean of a single score equals that score, and the missing new fields fall back to `summary_snippet`. Once the pipeline is re-run and new-schema data is ingested, the full multi-chunk behaviour activates automatically.
+
+## Data Contract
+
+### `VectorSearchRequest` (unchanged)
+| Field | Type | Behavior |
+|-------|------|----------|
+| `vector` | `float[]` | Query embedding, 384 dimensions |
+| `limit` | `int` | Distinct movies to return (1–50) |
+
+### `VectorSearchResponse` (unchanged)
+| Field | Type | Behavior |
+|-------|------|----------|
+| `results` | `List<MovieResult>` | Up to `limit` entries, fewer if pool yields fewer distinct movies |
+
+### `MovieResult` (updated — new field)
+| Field | Type | Behavior |
+|-------|------|----------|
+| `title` | `String` | Movie title |
+| `year` | `Integer` | Release year, nullable |
+| `genres` | `List<String>` | Genre list |
+| `score` | `float` | Arithmetic mean of all matching chunk scores |
+| `summarySnippet` | `String` | Full movie summary from `full_summary` Qdrant payload field |
+| `matchingSegment` | `String` | Chunk text of the highest-scoring chunk for this movie (new) |
+| `thumbnailUrl` | `String` | Poster URL, nullable |
+
+### `QdrantProperties` (updated — new field)
+| Field | Type | Default | Config key |
+|-------|------|---------|------------|
+| `baseUrl` | `String` | `http://localhost:6333` | `qdrant.base-url` |
+| `mock` | `boolean` | `false` | `qdrant.mock` |
+| `oversamplingFactor` | `int` | `20` | `qdrant.oversampling-factor` |
+
+`oversamplingFactor` valid range: **1–100** (inclusive). Values outside this range are treated as misconfiguration and clamped to the default of 20 at runtime. This is a runtime guard, not a startup validation failure — the service remains operational with a degraded-but-safe factor.
+
+### Qdrant request sent
+- Endpoint: `POST /collections/movies/points/search`
+- Body: `{ "vector": [...], "limit": limit * oversamplingFactor, "with_payload": true }`
+
+### Qdrant payload fields read (updated, with backwards-compat fallbacks)
+| JSON field | Mapped to | Fallback | Notes |
+|------------|-----------|----------|-------|
+| `movie_id` | grouping key | — | If null → chunk silently skipped |
+| `title` | `MovieResult.title` | — | |
+| `release_year` | `MovieResult.year` | — | |
+| `genres` | `MovieResult.genres` | — | |
+| `chunk_text` | `MovieResult.matchingSegment` | `summary_snippet` | Use `chunk_text` if non-null; fall back to `summary_snippet` for old-schema data |
+| `full_summary` | `MovieResult.summarySnippet` | `summary_snippet` | Use `full_summary` if non-null; fall back to `summary_snippet` for old-schema data |
+| `thumbnail_url` | `MovieResult.thumbnailUrl` | — | Processed by `absolutePosterUrl` |
+
+The fallback rule for both `matchingSegment` and `summarySnippet`: if the preferred new-schema field is null or absent, use `summary_snippet`. This allows the service to return correct results against an un-migrated Qdrant collection.
+
+## Dependencies
+
+| Dependency | Interface / Type | Injected As |
+|------------|-----------------|-------------|
+| `RestTemplate` | `org.springframework.web.client.RestTemplate` | Constructor |
+| `QdrantProperties` | Spring `@ConfigurationProperties` bean | Constructor |
+| `TmdbProperties` | Spring `@ConfigurationProperties` bean | Constructor |
+
+### Dependency Mock Behaviors
+
+#### RestTemplate
+
+| Scenario | Mock Setup | Notes |
+|----------|------------|-------|
+| Happy path | Returns `QdrantSearchResponse` with multiple chunks for multiple movies | Normal aggregation |
+| All chunks belong to one movie | Returns chunks all with same `movie_id` | Only one `MovieResult` returned |
+| Chunks with null `movie_id` | Some results have `payload.movie_id = null` | Those chunks skipped silently |
+| Empty result list | Returns `QdrantSearchResponse` with empty `result` | Returns `VectorSearchResponse` with empty list |
+| `ResourceAccessException` | Throws `ResourceAccessException` | Rethrown as `VectorSearchServiceException(CONNECTION_REFUSED)` |
+| Non-2xx HTTP status | Throws `HttpStatusCodeException` | Rethrown as `VectorSearchServiceException(NON_2XX_RESPONSE)` |
+
+**Mock data structures:**
+```json
+// Happy path: 3 chunks across 2 movies (movie "111" has 2 chunks, "222" has 1)
+// limit=2, oversamplingFactor=20 → fetch 40 chunks from Qdrant
+{
+  "result": [
+    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away", "release_year": 2000,
+      "genres": ["Drama"], "chunk_text": "He crash-lands on an island.",
+      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away", "release_year": 2000,
+      "genres": ["Drama"], "chunk_text": "He builds a raft.",
+      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien", "release_year": 1979,
+      "genres": ["Sci-Fi"], "chunk_text": "In space no one hears you.",
+      "full_summary": "Full Alien summary.", "thumbnail_url": null}}
+  ]
+}
+
+// Expected VectorSearchResponse:
+// movie "111": mean score = (0.90+0.70)/2 = 0.80, matchingSegment = "He crash-lands on an island."
+// movie "222": mean score = 0.85, matchingSegment = "In space no one hears you."
+// Sorted desc: Alien (0.85), Cast Away (0.80)
+
+// Null movie_id chunk (skipped):
+{"score": 0.95, "payload": {"movie_id": null, "title": "Ghost Movie", ...}}
+// → not included in any group
+
+// Empty result:
+{"result": []}
+// → VectorSearchResponse(results=[])
+```
+
+## Edge Cases
+
+| # | Input | Expected Output | Description | Mock Setup |
+|---|-------|----------------|-------------|------------|
+| 1 | All chunks for one movie | Single `MovieResult` with mean of all scores | Oversampling returned only one distinct movie | Chunks all share same `movie_id` |
+| 2 | Chunk with `movie_id = null` | Chunk excluded; other movies unaffected | Silent skip | Mix null and non-null `movie_id` in result |
+| 3 | Empty Qdrant result | `VectorSearchResponse(results=[])` | No matches | `result = []` |
+| 4 | Pool has fewer distinct movies than `limit` | Returns all distinct movies found | Fewer-than-limit is acceptable | Only N < limit distinct `movie_id`s |
+| 5 | One movie has higher mean score than one with a higher top chunk | Higher-mean movie ranked first | Mean pooling behavior is intentional | Multiple chunks with varying scores |
+| 6 | `ResourceAccessException` from RestTemplate | `VectorSearchServiceException(CONNECTION_REFUSED)` | Qdrant unreachable | `restTemplate.postForEntity` throws |
+| 7 | Non-2xx HTTP status from Qdrant | `VectorSearchServiceException(NON_2XX_RESPONSE)` | Bad request or server error | `restTemplate.postForEntity` throws `HttpStatusCodeException` |
+| 8 | `oversamplingFactor = 1` | Fetches `limit * 1` chunks | Minimum valid factor | `QdrantProperties.getOversamplingFactor()` returns 1 |
+| 9 | `qdrant.oversamplingFactor` missing from config | Defaults to 20 | Property has a default | Spring uses field default value |
+| 10 | Old-schema payload: `chunk_text` null, `full_summary` null, `summary_snippet` present | `matchingSegment` = `summary_snippet`; `summarySnippet` = `summary_snippet` | Backwards compat with un-migrated Qdrant data | Payload has only `summary_snippet` set |
+| 11 | Old-schema payload: single point per movie | Mean of one score = that score; one `MovieResult` per movie | No-op aggregation on un-migrated data | One result per distinct `movie_id` |
+| 12 | `oversamplingFactor` configured as `> 100` | Factor clamped to 20; `limit * 20` chunks fetched | Guard against misconfiguration causing oversized Qdrant queries | `QdrantProperties.getOversamplingFactor()` returns 150 |
+| 13 | `oversamplingFactor` configured as `≤ 0` | Factor clamped to 20; `limit * 20` chunks fetched | Guard against zero/negative misconfiguration | `QdrantProperties.getOversamplingFactor()` returns 0 or -1 |
+| 14 | `resp.getBody()` is null | Return empty `VectorSearchResponse` | Qdrant returns 200 with empty body | `restTemplate.postForEntity` returns response with null body |
+| 15 | `resp.getBody().result` is null | Return empty `VectorSearchResponse` | Body present but result field absent/null | `QdrantSearchResponse` with `result = null` |
+| 16 | Chunk has null `payload` | Chunk skipped silently; other chunks unaffected | Qdrant result with no payload object | One result in list has `payload = null` |
+
+## Unit Test Checklist
+
+- [ ] Happy path: 3 chunks (2 movies) → 2 `MovieResult`s sorted by mean score descending
+- [ ] `QdrantSearchRequest.limit` = `request.getLimit() * oversamplingFactor`
+- [ ] Movie with 2 chunks: `score` = arithmetic mean of both chunk scores
+- [ ] `matchingSegment` = `chunk_text` of highest-scoring chunk when `chunk_text` is non-null
+- [ ] `matchingSegment` = `summary_snippet` when `chunk_text` is null (old-schema fallback)
+- [ ] `summarySnippet` = `full_summary` from Qdrant payload when `full_summary` is non-null
+- [ ] `summarySnippet` = `summary_snippet` when `full_summary` is null (old-schema fallback)
+- [ ] Chunk with `movie_id = null` is excluded; other results unaffected
+- [ ] Empty Qdrant result → empty `VectorSearchResponse`
+- [ ] `ResourceAccessException` → `VectorSearchServiceException` with `CONNECTION_REFUSED` message
+- [ ] `HttpStatusCodeException` → `VectorSearchServiceException` with `NON_2XX_RESPONSE` message
+- [ ] Result count ≤ `request.getLimit()` even when pool has more distinct movies
+- [ ] `QdrantProperties`: missing `qdrant.oversampling-factor` uses default of 20
+- [ ] `QdrantProperties`: blank `qdrant.base-url` fails startup with `ConstraintViolationException`
+- [ ] `oversamplingFactor > 100` → effective factor is 20 (clamp to default)
+- [ ] `oversamplingFactor = 0` → effective factor is 20 (clamp to default)
+- [ ] `oversamplingFactor = -1` → effective factor is 20 (clamp to default)
+- [ ] Null response body → empty `VectorSearchResponse`, no exception
+- [ ] Null `result` field in response body → empty `VectorSearchResponse`, no exception
+- [ ] Chunk with null `payload` → skipped silently; remaining chunks still aggregated


### PR DESCRIPTION
## Summary
Add component specs for feature #267 — Multi-vector ingestion and mean-pooled search for full movie summaries.

## Changes
- `docs/specs/feature-267/SummaryChunker.md` — chunking algorithm spec
- `docs/specs/feature-267/EmbedCorpusPipeline.md` — updated embed pipeline spec
- `docs/specs/feature-267/IngestQdrantPipeline.md` — updated Qdrant ingestion spec
- `docs/specs/feature-267/VectorSearchServiceImpl.md` — mean-pooling API service spec with backwards-compat and safeguard edge cases

## Notes
Specs are non-functional documentation. Auto-merging without review cycle.