### PR TITLE
Update VectorSearchServiceImpl for multi-chunk mean-pooled search

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A portfolio project demonstrating AI-powered semantic search over the CMU Movie 
 
 Traditional keyword search fails when vocabulary doesn't match. Searching for "films about loneliness in space" won't find *Cast Away* because the plot summary never uses those words. Semantic search solves this by converting both the corpus and the query into dense vectors that capture *meaning*, not just tokens. This project implements that pipeline end-to-end, from raw text to a live search API.
 
-The target audience for this project is ML platform teams (e.g., Netflix ML Platform) that care about:
+The target audience for this project is ML platform teams that care about:
 - Serving ML models at scale with Triton Inference Server
 - Containerized infrastructure with Docker
 - Backend APIs in Java/Spring Boot

--- a/api/src/main/java/com/moviesearch/config/QdrantProperties.java
+++ b/api/src/main/java/com/moviesearch/config/QdrantProperties.java
@@ -11,9 +11,12 @@ public class QdrantProperties {
     @NotBlank
     private String baseUrl = "http://localhost:6333";
     private boolean mock = false;
+    private int oversamplingFactor = 20;
 
     public String getBaseUrl() { return baseUrl; }
     public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
     public boolean isMock() { return mock; }
     public void setMock(boolean mock) { this.mock = mock; }
+    public int getOversamplingFactor() { return oversamplingFactor; }
+    public void setOversamplingFactor(int oversamplingFactor) { this.oversamplingFactor = oversamplingFactor; }
 }

--- a/api/src/main/java/com/moviesearch/model/MovieResult.java
+++ b/api/src/main/java/com/moviesearch/model/MovieResult.java
@@ -13,5 +13,6 @@ public class MovieResult {
     List<String> genres;
     float score;
     String summarySnippet;
+    String matchingSegment;
     String thumbnailUrl;
 }

--- a/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
@@ -24,6 +24,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "Adventure"))
             .score(0.94f)
             .summarySnippet("A FedEx executive must transform himself physically and emotionally to survive a crash landing on a deserted island.")
+            .matchingSegment("A FedEx executive must transform himself physically and emotionally to survive.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -32,6 +33,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.91f)
             .summarySnippet("An astronaut becomes stranded on Mars after his team assumes him dead, and must rely on his ingenuity to survive.")
+            .matchingSegment("An astronaut becomes stranded on Mars after his team assumes him dead.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -40,6 +42,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Thriller"))
             .score(0.88f)
             .summarySnippet("Two astronauts work together to survive after an accident leaves them stranded in space.")
+            .matchingSegment("Two astronauts work together to survive after an accident leaves them stranded in space.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -48,6 +51,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.85f)
             .summarySnippet("A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.")
+            .matchingSegment("A team of explorers travel through a wormhole in space.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -56,6 +60,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "History", "Thriller"))
             .score(0.82f)
             .summarySnippet("NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage.")
+            .matchingSegment("NASA must devise a strategy to return Apollo 13 to Earth safely.")
             .thumbnailUrl(null)
             .build()
     );

--- a/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
@@ -15,13 +15,20 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Service
 @ConditionalOnProperty(name = "qdrant.mock", havingValue = "false", matchIfMissing = false)
 public class VectorSearchServiceImpl implements VectorSearchService {
 
+    private static final int OVERSAMPLING_DEFAULT = 20;
+    private static final int OVERSAMPLING_MAX = 100;
+
     private final RestTemplate restTemplate;
+    private final QdrantProperties properties;
     private final String searchUrl;
     private final String posterBaseUrl;
 
@@ -29,6 +36,7 @@ public class VectorSearchServiceImpl implements VectorSearchService {
                                    QdrantProperties properties,
                                    TmdbProperties tmdbProperties) {
         this.restTemplate = restTemplate;
+        this.properties = properties;
         this.searchUrl = properties.getBaseUrl() + "/collections/movies/points/search";
         String base = tmdbProperties.getPosterBaseUrl();
         this.posterBaseUrl = base == null ? "" : base.replaceAll("/+$", "");
@@ -49,20 +57,56 @@ public class VectorSearchServiceImpl implements VectorSearchService {
 
     @Override
     public VectorSearchResponse search(VectorSearchRequest request) {
-        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit());
+        int factor = properties.getOversamplingFactor();
+        if (factor <= 0 || factor > OVERSAMPLING_MAX) {
+            factor = OVERSAMPLING_DEFAULT;
+        }
+
+        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit() * factor);
         try {
             ResponseEntity<QdrantSearchResponse> resp =
                 restTemplate.postForEntity(searchUrl, body, QdrantSearchResponse.class);
-            List<MovieResult> results = resp.getBody().result.stream()
-                .map(r -> MovieResult.builder()
-                    .title(r.payload.title)
-                    .year(r.payload.releaseYear)
-                    .genres(r.payload.genres)
-                    .score(r.score)
-                    .summarySnippet(r.payload.summarySnippet)
-                    .thumbnailUrl(absolutePosterUrl(r.payload.thumbnailUrl))
-                    .build())
+
+            QdrantSearchResponse responseBody = resp.getBody();
+            if (responseBody == null || responseBody.result == null) {
+                return new VectorSearchResponse(List.of());
+            }
+
+            // Group chunks by movie_id; LinkedHashMap preserves insertion order (highest Qdrant score first per group)
+            LinkedHashMap<String, List<QdrantResult>> grouped = new LinkedHashMap<>();
+            for (QdrantResult r : responseBody.result) {
+                if (r.payload == null || r.payload.movieId == null) {
+                    continue;
+                }
+                grouped.computeIfAbsent(r.payload.movieId, k -> new ArrayList<>()).add(r);
+            }
+
+            List<MovieResult> results = grouped.values().stream()
+                .map(chunks -> {
+                    QdrantResult best = chunks.get(0); // highest-scoring chunk (Qdrant returns desc by score)
+                    double meanScore = chunks.stream().mapToDouble(c -> c.score).average().orElse(0.0);
+
+                    String matching = best.payload.chunkText != null
+                        ? best.payload.chunkText
+                        : best.payload.summarySnippet;
+                    String summary = best.payload.fullSummary != null
+                        ? best.payload.fullSummary
+                        : best.payload.summarySnippet;
+
+                    return MovieResult.builder()
+                        .title(best.payload.title)
+                        .year(best.payload.releaseYear)
+                        .genres(best.payload.genres)
+                        .score((float) meanScore)
+                        .summarySnippet(summary)
+                        .matchingSegment(matching)
+                        .thumbnailUrl(absolutePosterUrl(best.payload.thumbnailUrl))
+                        .build();
+                })
+                .sorted(Comparator.comparingDouble(MovieResult::getScore).reversed())
+                .limit(request.getLimit())
                 .toList();
+
             return new VectorSearchResponse(results);
         } catch (ResourceAccessException e) {
             throw new VectorSearchServiceException(VectorSearchServiceException.CONNECTION_REFUSED, e);
@@ -93,9 +137,12 @@ public class VectorSearchServiceImpl implements VectorSearchService {
 
     static class QdrantPayload {
         public String title;
-        @JsonProperty("release_year") public Integer releaseYear;
+        @JsonProperty("release_year")   public Integer releaseYear;
         public List<String> genres;
+        @JsonProperty("movie_id")       public String movieId;
+        @JsonProperty("chunk_text")     public String chunkText;
+        @JsonProperty("full_summary")   public String fullSummary;
         @JsonProperty("summary_snippet") public String summarySnippet;
-        @JsonProperty("thumbnail_url") public String thumbnailUrl;
+        @JsonProperty("thumbnail_url")  public String thumbnailUrl;
     }
 }

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
@@ -52,8 +52,8 @@ class VectorSearchServiceImplIntegrationTest {
         String qdrantResponse = """
                 {
                   "result": [
-                    {"id":1,"score":0.94,"payload":{"title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
-                    {"id":2,"score":0.91,"payload":{"title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
+                    {"id":1,"score":0.94,"payload":{"movie_id":"1","title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
+                    {"id":2,"score":0.91,"payload":{"movie_id":"2","title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
                   ]
                 }
                 """;

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
@@ -8,16 +8,25 @@ import com.moviesearch.model.VectorSearchRequest;
 import com.moviesearch.model.VectorSearchResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
@@ -43,97 +52,28 @@ class VectorSearchServiceImplTest {
         service = new VectorSearchServiceImpl(restTemplate, props, tmdb);
     }
 
+    // --- Multi-chunk aggregation ---
+
     @Test
-    void search_happyPath_returnsAllFieldsMapped() {
+    void search_threeChunksTwoMovies_returnsTwoResultsSortedByMeanScoreDesc() {
         server.expect(requestTo(SEARCH_URL))
             .andExpect(method(HttpMethod.POST))
             .andExpect(jsonPath("$.with_payload").value(true))
-            .andExpect(jsonPath("$.limit").value(5))
             .andRespond(withSuccess("""
                 {
                   "result": [
-                    {
-                      "score": 0.92,
-                      "payload": {
-                        "title": "Cast Away",
-                        "release_year": 2000,
-                        "genres": ["Drama", "Adventure"],
-                        "summary_snippet": "A FedEx executive stranded on an island.",
-                        "thumbnail_url": "https://example.com/cast-away.jpg"
-                      }
-                    }
-                  ]
-                }
-                """, MediaType.APPLICATION_JSON));
-
-        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
-
-        assertThat(response.getResults()).hasSize(1);
-        MovieResult result = response.getResults().get(0);
-        assertThat(result.getTitle()).isEqualTo("Cast Away");
-        assertThat(result.getYear()).isEqualTo(2000);
-        assertThat(result.getGenres()).containsExactly("Drama", "Adventure");
-        assertThat(result.getScore()).isEqualTo(0.92f);
-        assertThat(result.getSummarySnippet()).isEqualTo("A FedEx executive stranded on an island.");
-        assertThat(result.getThumbnailUrl()).isEqualTo("https://example.com/cast-away.jpg");
-
-        server.verify();
-    }
-
-    @Test
-    void search_nullThumbnailUrl_doesNotThrow() {
-        server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                {
-                  "result": [
-                    {
-                      "score": 0.85,
-                      "payload": {
-                        "title": "The Martian",
-                        "release_year": 2015,
-                        "genres": ["Science Fiction"],
-                        "summary_snippet": "An astronaut stranded on Mars.",
-                        "thumbnail_url": null
-                      }
-                    }
-                  ]
-                }
-                """, MediaType.APPLICATION_JSON));
-
-        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
-
-        assertThat(response.getResults()).hasSize(1);
-        assertThat(response.getResults().get(0).getThumbnailUrl()).isNull();
-
-        server.verify();
-    }
-
-    @Test
-    void search_multipleResults_allMapped() {
-        server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                {
-                  "result": [
-                    {
-                      "score": 0.92,
-                      "payload": {
-                        "title": "Movie A",
-                        "release_year": 2001,
-                        "genres": ["Action"],
-                        "summary_snippet": "Snippet A",
-                        "thumbnail_url": null
-                      }
-                    },
-                    {
-                      "score": 0.88,
-                      "payload": {
-                        "title": "Movie B",
-                        "release_year": 2002,
-                        "genres": ["Drama"],
-                        "summary_snippet": "Snippet B",
-                        "thumbnail_url": null
-                      }
-                    }
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands on an island.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He builds a raft.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space no one hears you.",
+                      "full_summary": "Full Alien summary.", "thumbnail_url": null}}
                   ]
                 }
                 """, MediaType.APPLICATION_JSON));
@@ -141,11 +81,304 @@ class VectorSearchServiceImplTest {
         VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
 
         assertThat(response.getResults()).hasSize(2);
-        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Movie A");
-        assertThat(response.getResults().get(1).getTitle()).isEqualTo("Movie B");
+        MovieResult first = response.getResults().get(0);
+        MovieResult second = response.getResults().get(1);
+
+        // Alien has mean 0.85, Cast Away has mean 0.80 → Alien ranked first
+        assertThat(first.getTitle()).isEqualTo("Alien");
+        assertThat(first.getScore()).isEqualTo(0.85f);
+        assertThat(first.getMatchingSegment()).isEqualTo("In space no one hears you.");
+        assertThat(first.getSummarySnippet()).isEqualTo("Full Alien summary.");
+
+        assertThat(second.getTitle()).isEqualTo("Cast Away");
+        assertThat(second.getScore()).isCloseTo(0.80f, within(0.001f));
+        assertThat(second.getMatchingSegment()).isEqualTo("He crash-lands on an island.");
+        assertThat(second.getSummarySnippet()).isEqualTo("Full Cast Away summary.");
 
         server.verify();
     }
+
+    @Test
+    void search_limitSentToQdrantIsLimitTimesOversamplingFactor() {
+        // Default oversamplingFactor=20, request limit=2 → Qdrant limit=40
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(40))
+            .andRespond(withSuccess("""
+                    { "result": [] }
+                    """, MediaType.APPLICATION_JSON));
+
+        service.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    @Test
+    void search_twoChunksSameMovie_scoreIsMeanOfBothChunks() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Movie X",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "Chunk A", "full_summary": "Full summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Movie X",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "Chunk B", "full_summary": "Full summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getScore()).isCloseTo(0.80f, within(0.001f));
+
+        server.verify();
+    }
+
+    @Test
+    void search_matchingSegmentUsesChunkTextWhenNonNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Movie X",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": "The best chunk.", "full_summary": "Full summary.",
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getMatchingSegment()).isEqualTo("The best chunk.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_matchingSegmentFallsBackToSummarySnippetWhenChunkTextIsNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Movie X",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": null, "full_summary": null,
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getMatchingSegment()).isEqualTo("Old snippet.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_summarySnippetUsesFullSummaryWhenNonNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Movie X",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": "A chunk.", "full_summary": "The complete summary.",
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getSummarySnippet()).isEqualTo("The complete summary.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_summarySnippetFallsBackToSummarySnippetWhenFullSummaryIsNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Movie X",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": null, "full_summary": null,
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getSummarySnippet()).isEqualTo("Old snippet.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullMovieId_chunkIsExcludedAndOtherResultsUnaffected() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": {"movie_id": null, "title": "Ghost",
+                      "release_year": 2020, "genres": [], "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space.", "full_summary": "Full summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Alien");
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullPayload_chunkIsSkippedSilently() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": null},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space.", "full_summary": "Full summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Alien");
+
+        server.verify();
+    }
+
+    @Test
+    void search_resultCountDoesNotExceedLimit() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "1", "title": "A",
+                      "release_year": 2000, "genres": [], "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "2", "title": "B",
+                      "release_year": 2001, "genres": [], "thumbnail_url": null}},
+                    {"score": 0.80, "payload": {"movie_id": "3", "title": "C",
+                      "release_year": 2002, "genres": [], "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
+
+        assertThat(response.getResults()).hasSize(2);
+
+        server.verify();
+    }
+
+    // --- Oversampling factor clamping ---
+
+    @Test
+    void search_oversamplingFactorOver100_clampsToDefault() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(150);
+        VectorSearchServiceImpl svc = new VectorSearchServiceImpl(restTemplate, props, new TmdbProperties());
+
+        // limit=2, factor clamped to 20 → Qdrant limit=40
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(40))
+            .andRespond(withSuccess("""
+                    { "result": [] }
+                    """, MediaType.APPLICATION_JSON));
+
+        svc.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorZero_clampsToDefault() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(0);
+        VectorSearchServiceImpl svc = new VectorSearchServiceImpl(restTemplate, props, new TmdbProperties());
+
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(40))
+            .andRespond(withSuccess("""
+                    { "result": [] }
+                    """, MediaType.APPLICATION_JSON));
+
+        svc.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorNegative_clampsToDefault() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(-1);
+        VectorSearchServiceImpl svc = new VectorSearchServiceImpl(restTemplate, props, new TmdbProperties());
+
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(40))
+            .andRespond(withSuccess("""
+                    { "result": [] }
+                    """, MediaType.APPLICATION_JSON));
+
+        svc.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    // --- Null guards ---
+
+    @Test
+    void search_nullResponseBody_returnsEmptyResponse() {
+        RestTemplate mockRt = Mockito.mock(RestTemplate.class);
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        VectorSearchServiceImpl svc = new VectorSearchServiceImpl(mockRt, props, tmdb);
+
+        Mockito.when(mockRt.postForEntity(eq(SEARCH_URL), any(), any()))
+            .thenReturn(ResponseEntity.ok(null));
+
+        VectorSearchResponse response = svc.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+    }
+
+    @Test
+    void search_nullResultFieldInBody_returnsEmptyResponse() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {}
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+
+        server.verify();
+    }
+
+    // --- Error handling ---
 
     @Test
     void search_networkFailure_throwsConnectionRefusedException() {
@@ -183,6 +416,8 @@ class VectorSearchServiceImplTest {
         server.verify();
     }
 
+    // --- Empty results ---
+
     @Test
     void search_emptyResultList_returnsEmptyResponse() {
         server.expect(requestTo(SEARCH_URL))
@@ -197,6 +432,37 @@ class VectorSearchServiceImplTest {
         server.verify();
     }
 
+    // --- Thumbnail URL handling ---
+
+    @Test
+    void search_nullThumbnailUrl_doesNotThrow() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {
+                      "score": 0.85,
+                      "payload": {
+                        "movie_id": "1",
+                        "title": "The Martian",
+                        "release_year": 2015,
+                        "genres": ["Science Fiction"],
+                        "summary_snippet": "An astronaut stranded on Mars.",
+                        "thumbnail_url": null
+                      }
+                    }
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getThumbnailUrl()).isNull();
+
+        server.verify();
+    }
+
     @Test
     void search_relativeThumbnailPath_isPrefixedWithPosterBaseUrl() {
         server.expect(requestTo(SEARCH_URL))
@@ -206,6 +472,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Galaxy Quest",
                         "release_year": 1999,
                         "genres": ["Science Fiction"],
@@ -234,6 +501,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Bare Path",
                         "release_year": 2010,
                         "genres": ["Drama"],
@@ -262,6 +530,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Already Absolute",
                         "release_year": 2020,
                         "genres": ["Drama"],
@@ -296,6 +565,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Trailing Slash",
                         "release_year": 2010,
                         "genres": ["Drama"],
@@ -326,5 +596,22 @@ class VectorSearchServiceImplTest {
         service.search(new VectorSearchRequest(VECTOR, 3));
 
         server.verify();
+    }
+
+    // --- QdrantProperties unit tests ---
+
+    @Test
+    void qdrantProperties_defaultOversamplingFactorIs20() {
+        QdrantProperties props = new QdrantProperties();
+        assertThat(props.getOversamplingFactor()).isEqualTo(20);
+    }
+
+    @Test
+    void qdrantProperties_blankBaseUrl_failsConstraintValidation() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl("");
+        Set<ConstraintViolation<QdrantProperties>> violations = validator.validate(props);
+        assertThat(violations).isNotEmpty();
     }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Overhauls `VectorSearchServiceImpl.search` to fetch `limit × oversamplingFactor` chunks from Qdrant, group by `movie_id`, mean-pool scores, and return up to `limit` distinct movies sorted by mean score descending
- Adds `oversamplingFactor` (default 20, clamped to 1–100 at runtime) to `QdrantProperties`
- Adds `matchingSegment` field to `MovieResult`; updates `MockVectorSearchService` to populate it
- Implements backwards-compat fallback reads: `chunk_text`→`summary_snippet` for `matchingSegment`, `full_summary`→`summary_snippet` for `summarySnippet`
- Null guards: skips chunks with null `payload` or null `movie_id`; handles null response body and null `result` array

## Test plan

- [ ] `./mvnw -f api/pom.xml test` — BUILD result matches pre-existing baseline (14 pre-existing Spring context errors from missing tokenizer model; 0 new failures)
- [ ] `VectorSearchServiceImplTest` — 27 tests covering all spec checklist items pass
- [ ] `VectorSearchServiceImplIntegrationTest` — 4 tests pass (payloads updated to include `movie_id` for old-schema backwards compat)

Closes #270

https://claude.ai/code/session_012BgmGDgyrx5B2Cc2i1gqgk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012BgmGDgyrx5B2Cc2i1gqgk)_