### PR TITLE
feat(#270): oversampled multi-chunk search with mean-pooled aggregation

### DIFF
--- a/api/src/main/java/com/moviesearch/config/QdrantProperties.java
+++ b/api/src/main/java/com/moviesearch/config/QdrantProperties.java
@@ -11,9 +11,12 @@ public class QdrantProperties {
     @NotBlank
     private String baseUrl = "http://localhost:6333";
     private boolean mock = false;
+    private int oversamplingFactor = 20;
 
     public String getBaseUrl() { return baseUrl; }
     public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
     public boolean isMock() { return mock; }
     public void setMock(boolean mock) { this.mock = mock; }
+    public int getOversamplingFactor() { return oversamplingFactor; }
+    public void setOversamplingFactor(int oversamplingFactor) { this.oversamplingFactor = oversamplingFactor; }
 }

--- a/api/src/main/java/com/moviesearch/model/MovieResult.java
+++ b/api/src/main/java/com/moviesearch/model/MovieResult.java
@@ -13,5 +13,6 @@ public class MovieResult {
     List<String> genres;
     float score;
     String summarySnippet;
+    String matchingSegment;
     String thumbnailUrl;
 }

--- a/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
@@ -24,6 +24,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "Adventure"))
             .score(0.94f)
             .summarySnippet("A FedEx executive must transform himself physically and emotionally to survive a crash landing on a deserted island.")
+            .matchingSegment("A FedEx executive must transform himself physically and emotionally to survive a crash landing on a deserted island.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -32,6 +33,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.91f)
             .summarySnippet("An astronaut becomes stranded on Mars after his team assumes him dead, and must rely on his ingenuity to survive.")
+            .matchingSegment("An astronaut becomes stranded on Mars after his team assumes him dead, and must rely on his ingenuity to survive.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -40,6 +42,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Thriller"))
             .score(0.88f)
             .summarySnippet("Two astronauts work together to survive after an accident leaves them stranded in space.")
+            .matchingSegment("Two astronauts work together to survive after an accident leaves them stranded in space.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -48,6 +51,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.85f)
             .summarySnippet("A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.")
+            .matchingSegment("A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -56,6 +60,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "History", "Thriller"))
             .score(0.82f)
             .summarySnippet("NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage.")
+            .matchingSegment("NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage.")
             .thumbnailUrl(null)
             .build()
     );

--- a/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
@@ -15,13 +15,20 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Service
 @ConditionalOnProperty(name = "qdrant.mock", havingValue = "false", matchIfMissing = false)
 public class VectorSearchServiceImpl implements VectorSearchService {
 
+    private static final int OVERSAMPLING_DEFAULT = 20;
+    private static final int OVERSAMPLING_MAX = 100;
+
     private final RestTemplate restTemplate;
+    private final QdrantProperties properties;
     private final String searchUrl;
     private final String posterBaseUrl;
 
@@ -29,6 +36,7 @@ public class VectorSearchServiceImpl implements VectorSearchService {
                                    QdrantProperties properties,
                                    TmdbProperties tmdbProperties) {
         this.restTemplate = restTemplate;
+        this.properties = properties;
         this.searchUrl = properties.getBaseUrl() + "/collections/movies/points/search";
         String base = tmdbProperties.getPosterBaseUrl();
         this.posterBaseUrl = base == null ? "" : base.replaceAll("/+$", "");
@@ -49,20 +57,49 @@ public class VectorSearchServiceImpl implements VectorSearchService {
 
     @Override
     public VectorSearchResponse search(VectorSearchRequest request) {
-        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit());
+        int factor = properties.getOversamplingFactor();
+        if (factor <= 0 || factor > OVERSAMPLING_MAX) {
+            factor = OVERSAMPLING_DEFAULT;
+        }
+
+        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit() * factor);
         try {
             ResponseEntity<QdrantSearchResponse> resp =
                 restTemplate.postForEntity(searchUrl, body, QdrantSearchResponse.class);
-            List<MovieResult> results = resp.getBody().result.stream()
-                .map(r -> MovieResult.builder()
-                    .title(r.payload.title)
-                    .year(r.payload.releaseYear)
-                    .genres(r.payload.genres)
-                    .score(r.score)
-                    .summarySnippet(r.payload.summarySnippet)
-                    .thumbnailUrl(absolutePosterUrl(r.payload.thumbnailUrl))
-                    .build())
+
+            QdrantSearchResponse responseBody = resp.getBody();
+            if (responseBody == null || responseBody.result == null) {
+                return new VectorSearchResponse(List.of());
+            }
+
+            LinkedHashMap<String, List<QdrantResult>> grouped = new LinkedHashMap<>();
+            for (QdrantResult r : responseBody.result) {
+                if (r.payload == null || r.payload.movieId == null) continue;
+                grouped.computeIfAbsent(r.payload.movieId, k -> new ArrayList<>()).add(r);
+            }
+
+            List<MovieResult> results = grouped.values().stream()
+                .map(chunks -> {
+                    QdrantResult best = chunks.get(0);
+                    double meanScore = chunks.stream().mapToDouble(c -> c.score).average().orElse(0.0);
+                    String matching = best.payload.chunkText != null
+                        ? best.payload.chunkText : best.payload.summarySnippet;
+                    String summary = best.payload.fullSummary != null
+                        ? best.payload.fullSummary : best.payload.summarySnippet;
+                    return MovieResult.builder()
+                        .title(best.payload.title)
+                        .year(best.payload.releaseYear)
+                        .genres(best.payload.genres)
+                        .score((float) meanScore)
+                        .summarySnippet(summary)
+                        .matchingSegment(matching)
+                        .thumbnailUrl(absolutePosterUrl(best.payload.thumbnailUrl))
+                        .build();
+                })
+                .sorted(Comparator.comparingDouble(MovieResult::getScore).reversed())
+                .limit(request.getLimit())
                 .toList();
+
             return new VectorSearchResponse(results);
         } catch (ResourceAccessException e) {
             throw new VectorSearchServiceException(VectorSearchServiceException.CONNECTION_REFUSED, e);
@@ -92,9 +129,12 @@ public class VectorSearchServiceImpl implements VectorSearchService {
     }
 
     static class QdrantPayload {
+        @JsonProperty("movie_id")     public String movieId;
         public String title;
         @JsonProperty("release_year") public Integer releaseYear;
         public List<String> genres;
+        @JsonProperty("chunk_text")   public String chunkText;
+        @JsonProperty("full_summary") public String fullSummary;
         @JsonProperty("summary_snippet") public String summarySnippet;
         @JsonProperty("thumbnail_url") public String thumbnailUrl;
     }

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
@@ -52,8 +52,8 @@ class VectorSearchServiceImplIntegrationTest {
         String qdrantResponse = """
                 {
                   "result": [
-                    {"id":1,"score":0.94,"payload":{"title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
-                    {"id":2,"score":0.91,"payload":{"title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
+                    {"id":1,"score":0.94,"payload":{"movie_id":"cast-away","title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
+                    {"id":2,"score":0.91,"payload":{"movie_id":"the-martian","title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
                   ]
                 }
                 """;

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
@@ -16,6 +16,8 @@ import org.springframework.web.client.RestTemplate;
 import java.io.IOException;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.within;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
@@ -38,10 +40,13 @@ class VectorSearchServiceImplTest {
         server = MockRestServiceServer.createServer(restTemplate);
         QdrantProperties props = new QdrantProperties();
         props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(1);
         TmdbProperties tmdb = new TmdbProperties();
         tmdb.setPosterBaseUrl(POSTER_BASE_URL);
         service = new VectorSearchServiceImpl(restTemplate, props, tmdb);
     }
+
+    // ── existing mapping tests (updated: movie_id added to all payloads) ──
 
     @Test
     void search_happyPath_returnsAllFieldsMapped() {
@@ -55,6 +60,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.92,
                       "payload": {
+                        "movie_id": "cast-away",
                         "title": "Cast Away",
                         "release_year": 2000,
                         "genres": ["Drama", "Adventure"],
@@ -89,6 +95,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.85,
                       "payload": {
+                        "movie_id": "the-martian",
                         "title": "The Martian",
                         "release_year": 2015,
                         "genres": ["Science Fiction"],
@@ -117,6 +124,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.92,
                       "payload": {
+                        "movie_id": "m1",
                         "title": "Movie A",
                         "release_year": 2001,
                         "genres": ["Action"],
@@ -127,6 +135,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.88,
                       "payload": {
+                        "movie_id": "m2",
                         "title": "Movie B",
                         "release_year": 2002,
                         "genres": ["Drama"],
@@ -206,6 +215,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "gq",
                         "title": "Galaxy Quest",
                         "release_year": 1999,
                         "genres": ["Science Fiction"],
@@ -234,6 +244,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "bp",
                         "title": "Bare Path",
                         "release_year": 2010,
                         "genres": ["Drama"],
@@ -262,6 +273,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "aa",
                         "title": "Already Absolute",
                         "release_year": 2020,
                         "genres": ["Drama"],
@@ -285,6 +297,7 @@ class VectorSearchServiceImplTest {
     void search_posterBaseUrlWithTrailingSlash_isNormalized() {
         QdrantProperties props = new QdrantProperties();
         props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(1);
         TmdbProperties tmdb = new TmdbProperties();
         tmdb.setPosterBaseUrl(POSTER_BASE_URL + "/");
         VectorSearchServiceImpl localService = new VectorSearchServiceImpl(restTemplate, props, tmdb);
@@ -296,6 +309,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "ts",
                         "title": "Trailing Slash",
                         "release_year": 2010,
                         "genres": ["Drama"],
@@ -326,5 +340,342 @@ class VectorSearchServiceImplTest {
         service.search(new VectorSearchRequest(VECTOR, 3));
 
         server.verify();
+    }
+
+    // ── multi-chunk aggregation tests ──
+
+    @Test
+    void search_multiChunk_returnsDistinctMoviesSortedByMeanScoreDescending() {
+        // movie "111" has 2 chunks (scores 0.90 + 0.70) → mean 0.80
+        // movie "222" has 1 chunk (score 0.85) → mean 0.85
+        // expected order: "Alien" (0.85) first, "Cast Away" (0.80) second
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(2))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands on an island.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He builds a raft.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space no one hears you.",
+                      "full_summary": "Full Alien summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
+
+        assertThat(response.getResults()).hasSize(2);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Alien");
+        assertThat(response.getResults().get(1).getTitle()).isEqualTo("Cast Away");
+
+        server.verify();
+    }
+
+    @Test
+    void search_twoChunksSameMovie_meanScoreComputed() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands on an island.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He builds a raft.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getScore()).isCloseTo(0.80f, within(0.001f));
+
+        server.verify();
+    }
+
+    @Test
+    void search_matchingSegmentFromChunkText() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands on an island.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He builds a raft.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getMatchingSegment())
+            .isEqualTo("He crash-lands on an island.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_matchingSegmentFallsBackToSummarySnippetWhenChunkTextNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.85, "payload": {"movie_id": "old-1", "title": "Old Movie",
+                      "release_year": 2010, "genres": ["Drama"],
+                      "summary_snippet": "Old schema snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getMatchingSegment())
+            .isEqualTo("Old schema snippet.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_summarySnippetFromFullSummary() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.85, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getSummarySnippet())
+            .isEqualTo("Full Cast Away summary.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_summarySnippetFallsBackToSummarySnippetWhenFullSummaryNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.85, "payload": {"movie_id": "old-1", "title": "Old Movie",
+                      "release_year": 2010, "genres": ["Drama"],
+                      "summary_snippet": "Old schema snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getSummarySnippet())
+            .isEqualTo("Old schema snippet.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullMovieId_chunkSkipped() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": {"movie_id": null, "title": "Ghost Movie",
+                      "release_year": 2020, "genres": ["Horror"],
+                      "summary_snippet": "Should be skipped.", "thumbnail_url": null}},
+                    {"score": 0.80, "payload": {"movie_id": "valid-1", "title": "Valid Movie",
+                      "release_year": 2021, "genres": ["Drama"],
+                      "summary_snippet": "Valid snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Valid Movie");
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullPayload_chunkSkipped() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": null},
+                    {"score": 0.80, "payload": {"movie_id": "valid-1", "title": "Valid Movie",
+                      "release_year": 2021, "genres": ["Drama"],
+                      "summary_snippet": "Valid snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Valid Movie");
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullResponseBody_returnsEmpty() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullResultArray_returnsEmpty() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                { "result": null }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+
+        server.verify();
+    }
+
+    @Test
+    void search_resultCountLimitedByRequestLimit() {
+        // 3 distinct movies in pool, but limit=2
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(2))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "m1", "title": "Movie 1",
+                      "release_year": 2001, "genres": ["Action"],
+                      "summary_snippet": "s1", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "m2", "title": "Movie 2",
+                      "release_year": 2002, "genres": ["Drama"],
+                      "summary_snippet": "s2", "thumbnail_url": null}},
+                    {"score": 0.80, "payload": {"movie_id": "m3", "title": "Movie 3",
+                      "release_year": 2003, "genres": ["Comedy"],
+                      "summary_snippet": "s3", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
+
+        assertThat(response.getResults()).hasSize(2);
+
+        server.verify();
+    }
+
+    // ── oversampling factor tests ──
+
+    @Test
+    void search_oversamplingFactorSentToQdrant() {
+        RestTemplate rt = new RestTemplate();
+        MockRestServiceServer localServer = MockRestServiceServer.createServer(rt);
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(5);
+        TmdbProperties tmdb = new TmdbProperties();
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(rt, props, tmdb);
+
+        localServer.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(10))  // 2 * 5
+            .andRespond(withSuccess("{ \"result\": [] }", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 2));
+
+        localServer.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorDefaultIs20() {
+        QdrantProperties props = new QdrantProperties();
+        assertThat(props.getOversamplingFactor()).isEqualTo(20);
+    }
+
+    @Test
+    void search_oversamplingFactorClampedWhenTooHigh() {
+        RestTemplate rt = new RestTemplate();
+        MockRestServiceServer localServer = MockRestServiceServer.createServer(rt);
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(150);
+        TmdbProperties tmdb = new TmdbProperties();
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(rt, props, tmdb);
+
+        localServer.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(100))  // 5 * 20 (clamped)
+            .andRespond(withSuccess("{ \"result\": [] }", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 5));
+
+        localServer.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorClampedWhenZero() {
+        RestTemplate rt = new RestTemplate();
+        MockRestServiceServer localServer = MockRestServiceServer.createServer(rt);
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(0);
+        TmdbProperties tmdb = new TmdbProperties();
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(rt, props, tmdb);
+
+        localServer.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(100))  // 5 * 20 (clamped)
+            .andRespond(withSuccess("{ \"result\": [] }", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 5));
+
+        localServer.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorClampedWhenNegative() {
+        RestTemplate rt = new RestTemplate();
+        MockRestServiceServer localServer = MockRestServiceServer.createServer(rt);
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(-1);
+        TmdbProperties tmdb = new TmdbProperties();
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(rt, props, tmdb);
+
+        localServer.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(100))  // 5 * 20 (clamped)
+            .andRespond(withSuccess("{ \"result\": [] }", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 5));
+
+        localServer.verify();
     }
 }


### PR DESCRIPTION
## Summary

- **`QdrantProperties`**: adds `oversamplingFactor` field (default 20, clamped to 20 when configured outside 1–100)
- **`MovieResult`**: adds `matchingSegment` field (highest-scoring chunk text for the movie)
- **`VectorSearchServiceImpl`**: fetches `limit × oversamplingFactor` chunks, groups by `movie_id`, computes arithmetic mean score per movie, returns up to `limit` distinct movies sorted descending; includes null guards (null body, null result, null payload, null `movie_id`) and backwards-compat fallbacks (`chunk_text → summary_snippet`, `full_summary → summary_snippet`) for un-migrated Qdrant data
- **`MockVectorSearchService`**: populates `matchingSegment` with a hardcoded excerpt per result
- **`VectorSearchServiceImplTest`**: 28 Mockito-based unit tests covering all spec checklist items
- **`VectorSearchServiceImplIntegrationTest`**: adds `movie_id` to mock payloads so results are not silently skipped by the new implementation

## Test plan

- [ ] `./mvnw -f api/pom.xml test -Dtest="VectorSearchServiceImplTest"` — 28 tests pass
- [ ] `./mvnw -f api/pom.xml test -Dtest="VectorSearchServiceImplIntegrationTest"` — 4 tests pass
- [ ] `./mvnw -f api/pom.xml test -Dtest="MockVectorSearchServiceTest"` — 6 tests pass
- [ ] All spec checklist items in `docs/specs/feature-267/VectorSearchServiceImpl.md` covered

Closes #270
Part of #267

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSU9nLdk5DeQuaCynf4RaE)_