### PR TITLE
Add multi-chunk mean-pooled search to VectorSearchServiceImpl (#270)

### DIFF
--- a/api/src/main/java/com/moviesearch/config/QdrantProperties.java
+++ b/api/src/main/java/com/moviesearch/config/QdrantProperties.java
@@ -11,9 +11,12 @@ public class QdrantProperties {
     @NotBlank
     private String baseUrl = "http://localhost:6333";
     private boolean mock = false;
+    private int oversamplingFactor = 20;
 
     public String getBaseUrl() { return baseUrl; }
     public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
     public boolean isMock() { return mock; }
     public void setMock(boolean mock) { this.mock = mock; }
+    public int getOversamplingFactor() { return oversamplingFactor; }
+    public void setOversamplingFactor(int oversamplingFactor) { this.oversamplingFactor = oversamplingFactor; }
 }

--- a/api/src/main/java/com/moviesearch/model/MovieResult.java
+++ b/api/src/main/java/com/moviesearch/model/MovieResult.java
@@ -13,5 +13,6 @@ public class MovieResult {
     List<String> genres;
     float score;
     String summarySnippet;
+    String matchingSegment;
     String thumbnailUrl;
 }

--- a/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
@@ -24,6 +24,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "Adventure"))
             .score(0.94f)
             .summarySnippet("A FedEx executive must transform himself physically and emotionally to survive a crash landing on a deserted island.")
+            .matchingSegment("A FedEx executive must transform himself physically and emotionally to survive a crash landing on a deserted island.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -32,6 +33,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.91f)
             .summarySnippet("An astronaut becomes stranded on Mars after his team assumes him dead, and must rely on his ingenuity to survive.")
+            .matchingSegment("An astronaut becomes stranded on Mars after his team assumes him dead, and must rely on his ingenuity to survive.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -40,6 +42,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Thriller"))
             .score(0.88f)
             .summarySnippet("Two astronauts work together to survive after an accident leaves them stranded in space.")
+            .matchingSegment("Two astronauts work together to survive after an accident leaves them stranded in space.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -48,6 +51,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.85f)
             .summarySnippet("A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.")
+            .matchingSegment("A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -56,6 +60,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "History", "Thriller"))
             .score(0.82f)
             .summarySnippet("NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage.")
+            .matchingSegment("NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage.")
             .thumbnailUrl(null)
             .build()
     );

--- a/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
@@ -15,13 +15,20 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Service
 @ConditionalOnProperty(name = "qdrant.mock", havingValue = "false", matchIfMissing = false)
 public class VectorSearchServiceImpl implements VectorSearchService {
 
+    private static final int OVERSAMPLING_DEFAULT = 20;
+    private static final int OVERSAMPLING_MAX = 100;
+
     private final RestTemplate restTemplate;
+    private final QdrantProperties properties;
     private final String searchUrl;
     private final String posterBaseUrl;
 
@@ -29,6 +36,7 @@ public class VectorSearchServiceImpl implements VectorSearchService {
                                    QdrantProperties properties,
                                    TmdbProperties tmdbProperties) {
         this.restTemplate = restTemplate;
+        this.properties = properties;
         this.searchUrl = properties.getBaseUrl() + "/collections/movies/points/search";
         String base = tmdbProperties.getPosterBaseUrl();
         this.posterBaseUrl = base == null ? "" : base.replaceAll("/+$", "");
@@ -49,20 +57,49 @@ public class VectorSearchServiceImpl implements VectorSearchService {
 
     @Override
     public VectorSearchResponse search(VectorSearchRequest request) {
-        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit());
+        int factor = properties.getOversamplingFactor();
+        if (factor <= 0 || factor > OVERSAMPLING_MAX) {
+            factor = OVERSAMPLING_DEFAULT;
+        }
+
+        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit() * factor);
         try {
             ResponseEntity<QdrantSearchResponse> resp =
                 restTemplate.postForEntity(searchUrl, body, QdrantSearchResponse.class);
-            List<MovieResult> results = resp.getBody().result.stream()
-                .map(r -> MovieResult.builder()
-                    .title(r.payload.title)
-                    .year(r.payload.releaseYear)
-                    .genres(r.payload.genres)
-                    .score(r.score)
-                    .summarySnippet(r.payload.summarySnippet)
-                    .thumbnailUrl(absolutePosterUrl(r.payload.thumbnailUrl))
-                    .build())
+
+            QdrantSearchResponse responseBody = resp.getBody();
+            if (responseBody == null || responseBody.result == null) {
+                return new VectorSearchResponse(List.of());
+            }
+
+            LinkedHashMap<String, List<QdrantResult>> grouped = new LinkedHashMap<>();
+            for (QdrantResult r : responseBody.result) {
+                if (r.payload == null || r.payload.movieId == null) continue;
+                grouped.computeIfAbsent(r.payload.movieId, k -> new ArrayList<>()).add(r);
+            }
+
+            List<MovieResult> results = grouped.values().stream()
+                .map(chunks -> {
+                    QdrantResult best = chunks.get(0);
+                    float meanScore = (float) chunks.stream().mapToDouble(c -> c.score).average().orElse(0.0);
+                    String matching = best.payload.chunkText != null
+                        ? best.payload.chunkText : best.payload.summarySnippet;
+                    String summary = best.payload.fullSummary != null
+                        ? best.payload.fullSummary : best.payload.summarySnippet;
+                    return MovieResult.builder()
+                        .title(best.payload.title)
+                        .year(best.payload.releaseYear)
+                        .genres(best.payload.genres)
+                        .score(meanScore)
+                        .matchingSegment(matching)
+                        .summarySnippet(summary)
+                        .thumbnailUrl(absolutePosterUrl(best.payload.thumbnailUrl))
+                        .build();
+                })
+                .sorted(Comparator.comparingDouble(MovieResult::getScore).reversed())
+                .limit(request.getLimit())
                 .toList();
+
             return new VectorSearchResponse(results);
         } catch (ResourceAccessException e) {
             throw new VectorSearchServiceException(VectorSearchServiceException.CONNECTION_REFUSED, e);
@@ -92,10 +129,13 @@ public class VectorSearchServiceImpl implements VectorSearchService {
     }
 
     static class QdrantPayload {
+        @JsonProperty("movie_id")       public String movieId;
         public String title;
-        @JsonProperty("release_year") public Integer releaseYear;
+        @JsonProperty("release_year")   public Integer releaseYear;
         public List<String> genres;
+        @JsonProperty("chunk_text")     public String chunkText;
+        @JsonProperty("full_summary")   public String fullSummary;
         @JsonProperty("summary_snippet") public String summarySnippet;
-        @JsonProperty("thumbnail_url") public String thumbnailUrl;
+        @JsonProperty("thumbnail_url")  public String thumbnailUrl;
     }
 }

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
@@ -52,8 +52,8 @@ class VectorSearchServiceImplIntegrationTest {
         String qdrantResponse = """
                 {
                   "result": [
-                    {"id":1,"score":0.94,"payload":{"title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
-                    {"id":2,"score":0.91,"payload":{"title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
+                    {"id":1,"score":0.94,"payload":{"movie_id":"111","title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
+                    {"id":2,"score":0.91,"payload":{"movie_id":"222","title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
                   ]
                 }
                 """;

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
@@ -6,10 +6,17 @@ import com.moviesearch.exception.VectorSearchServiceException;
 import com.moviesearch.model.MovieResult;
 import com.moviesearch.model.VectorSearchRequest;
 import com.moviesearch.model.VectorSearchResponse;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
@@ -18,9 +25,14 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
+@ExtendWith(MockitoExtension.class)
 class VectorSearchServiceImplTest {
 
     private static final String BASE_URL = "http://qdrant-test:6333";
@@ -28,112 +40,65 @@ class VectorSearchServiceImplTest {
     private static final String POSTER_BASE_URL = "https://image.tmdb.org/t/p/w200";
     private static final float[] VECTOR = new float[]{0.1f, 0.2f, 0.3f};
 
+    // HTTP-level test infrastructure
     private RestTemplate restTemplate;
     private MockRestServiceServer server;
     private VectorSearchServiceImpl service;
+
+    // Mockito-based infrastructure for edge cases requiring null bodies etc.
+    @Mock
+    private RestTemplate mockRestTemplate;
+    private VectorSearchServiceImpl mockService;
 
     @BeforeEach
     void setUp() {
         restTemplate = new RestTemplate();
         server = MockRestServiceServer.createServer(restTemplate);
+
         QdrantProperties props = new QdrantProperties();
         props.setBaseUrl(BASE_URL);
         TmdbProperties tmdb = new TmdbProperties();
         tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+
         service = new VectorSearchServiceImpl(restTemplate, props, tmdb);
+        mockService = new VectorSearchServiceImpl(mockRestTemplate, props, tmdb);
     }
 
+    private VectorSearchServiceImpl serviceWithFactor(int factor) {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(factor);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        return new VectorSearchServiceImpl(restTemplate, props, tmdb);
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path: multi-chunk aggregation
+    // -------------------------------------------------------------------------
+
     @Test
-    void search_happyPath_returnsAllFieldsMapped() {
+    void search_happyPath_threeChunksTwoMovies_returnsTwoResultsSortedByMeanScore() {
+        // limit=2, default factor=20 → Qdrant limit=40
         server.expect(requestTo(SEARCH_URL))
             .andExpect(method(HttpMethod.POST))
             .andExpect(jsonPath("$.with_payload").value(true))
-            .andExpect(jsonPath("$.limit").value(5))
+            .andExpect(jsonPath("$.limit").value(2 * 20))
             .andRespond(withSuccess("""
                 {
                   "result": [
-                    {
-                      "score": 0.92,
-                      "payload": {
-                        "title": "Cast Away",
-                        "release_year": 2000,
-                        "genres": ["Drama", "Adventure"],
-                        "summary_snippet": "A FedEx executive stranded on an island.",
-                        "thumbnail_url": "https://example.com/cast-away.jpg"
-                      }
-                    }
-                  ]
-                }
-                """, MediaType.APPLICATION_JSON));
-
-        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
-
-        assertThat(response.getResults()).hasSize(1);
-        MovieResult result = response.getResults().get(0);
-        assertThat(result.getTitle()).isEqualTo("Cast Away");
-        assertThat(result.getYear()).isEqualTo(2000);
-        assertThat(result.getGenres()).containsExactly("Drama", "Adventure");
-        assertThat(result.getScore()).isEqualTo(0.92f);
-        assertThat(result.getSummarySnippet()).isEqualTo("A FedEx executive stranded on an island.");
-        assertThat(result.getThumbnailUrl()).isEqualTo("https://example.com/cast-away.jpg");
-
-        server.verify();
-    }
-
-    @Test
-    void search_nullThumbnailUrl_doesNotThrow() {
-        server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                {
-                  "result": [
-                    {
-                      "score": 0.85,
-                      "payload": {
-                        "title": "The Martian",
-                        "release_year": 2015,
-                        "genres": ["Science Fiction"],
-                        "summary_snippet": "An astronaut stranded on Mars.",
-                        "thumbnail_url": null
-                      }
-                    }
-                  ]
-                }
-                """, MediaType.APPLICATION_JSON));
-
-        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
-
-        assertThat(response.getResults()).hasSize(1);
-        assertThat(response.getResults().get(0).getThumbnailUrl()).isNull();
-
-        server.verify();
-    }
-
-    @Test
-    void search_multipleResults_allMapped() {
-        server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                {
-                  "result": [
-                    {
-                      "score": 0.92,
-                      "payload": {
-                        "title": "Movie A",
-                        "release_year": 2001,
-                        "genres": ["Action"],
-                        "summary_snippet": "Snippet A",
-                        "thumbnail_url": null
-                      }
-                    },
-                    {
-                      "score": 0.88,
-                      "payload": {
-                        "title": "Movie B",
-                        "release_year": 2002,
-                        "genres": ["Drama"],
-                        "summary_snippet": "Snippet B",
-                        "thumbnail_url": null
-                      }
-                    }
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands on an island.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He builds a raft.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space no one hears you.",
+                      "full_summary": "Full Alien summary.", "thumbnail_url": null}}
                   ]
                 }
                 """, MediaType.APPLICATION_JSON));
@@ -141,11 +106,313 @@ class VectorSearchServiceImplTest {
         VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
 
         assertThat(response.getResults()).hasSize(2);
-        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Movie A");
-        assertThat(response.getResults().get(1).getTitle()).isEqualTo("Movie B");
+
+        // Alien: single chunk score = 0.85, sorted first
+        MovieResult alien = response.getResults().get(0);
+        assertThat(alien.getTitle()).isEqualTo("Alien");
+        assertThat(alien.getScore()).isCloseTo(0.85f, within(0.001f));
+        assertThat(alien.getMatchingSegment()).isEqualTo("In space no one hears you.");
+        assertThat(alien.getSummarySnippet()).isEqualTo("Full Alien summary.");
+
+        // Cast Away: mean of (0.90 + 0.70) / 2 = 0.80, sorted second
+        MovieResult castAway = response.getResults().get(1);
+        assertThat(castAway.getTitle()).isEqualTo("Cast Away");
+        assertThat(castAway.getScore()).isCloseTo(0.80f, within(0.001f));
+        assertThat(castAway.getMatchingSegment()).isEqualTo("He crash-lands on an island.");
+        assertThat(castAway.getSummarySnippet()).isEqualTo("Full Cast Away summary.");
 
         server.verify();
     }
+
+    @Test
+    void search_twoChunks_scoreIsArithmeticMean() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Movie",
+                      "release_year": 2000, "genres": [], "chunk_text": "chunk1",
+                      "full_summary": "summary", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Movie",
+                      "release_year": 2000, "genres": [], "chunk_text": "chunk2",
+                      "full_summary": "summary", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getScore()).isCloseTo(0.80f, within(0.001f));
+    }
+
+    @Test
+    void search_matchingSegment_isHighestScoringChunkText() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Movie",
+                      "release_year": 2000, "genres": [], "chunk_text": "best chunk",
+                      "full_summary": "full", "thumbnail_url": null}},
+                    {"score": 0.50, "payload": {"movie_id": "111", "title": "Movie",
+                      "release_year": 2000, "genres": [], "chunk_text": "worse chunk",
+                      "full_summary": "full", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getMatchingSegment()).isEqualTo("best chunk");
+    }
+
+    @Test
+    void search_summarySnippet_isFullSummaryFromPayload() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Movie",
+                      "release_year": 2000, "genres": [], "chunk_text": "a chunk",
+                      "full_summary": "The complete full summary.",
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getSummarySnippet()).isEqualTo("The complete full summary.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Backwards-compat: old-schema fallback (no chunk_text / full_summary)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void search_matchingSegment_fallsBackToSummarySnippet_whenChunkTextNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.85, "payload": {"movie_id": "111", "title": "Old Movie",
+                      "release_year": 1990, "genres": ["Drama"],
+                      "summary_snippet": "Old snippet text.",
+                      "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getMatchingSegment()).isEqualTo("Old snippet text.");
+    }
+
+    @Test
+    void search_summarySnippet_fallsBackToSummarySnippet_whenFullSummaryNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.85, "payload": {"movie_id": "111", "title": "Old Movie",
+                      "release_year": 1990, "genres": ["Drama"],
+                      "summary_snippet": "Old snippet text.",
+                      "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getSummarySnippet()).isEqualTo("Old snippet text.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Null / missing payload guards
+    // -------------------------------------------------------------------------
+
+    @Test
+    void search_nullMovieId_chunkIsExcluded() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": {"movie_id": null, "title": "Ghost",
+                      "release_year": 2000, "genres": [], "chunk_text": "x", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Real Movie",
+                      "release_year": 2001, "genres": [], "chunk_text": "y",
+                      "full_summary": "full", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Real Movie");
+    }
+
+    @Test
+    void search_nullPayload_chunkSkipped() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": null},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Valid",
+                      "release_year": 2001, "genres": [], "chunk_text": "y",
+                      "full_summary": "full", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Valid");
+    }
+
+    @Test
+    void search_nullResponseBody_returnsEmptyResponse() {
+        when(mockRestTemplate.postForEntity(anyString(), any(), any()))
+            .thenReturn(ResponseEntity.ok(null));
+
+        VectorSearchResponse response = mockService.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+    }
+
+    @Test
+    void search_nullResultField_returnsEmptyResponse() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                { "result": null }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+    }
+
+    @Test
+    void search_emptyResult_returnsEmptyResponse() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+        server.verify();
+    }
+
+    // -------------------------------------------------------------------------
+    // Limit enforcement
+    // -------------------------------------------------------------------------
+
+    @Test
+    void search_resultCount_doesNotExceedLimit() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": {"movie_id": "1", "title": "A",
+                      "release_year": 2000, "genres": [], "chunk_text": "a",
+                      "full_summary": "fa", "thumbnail_url": null}},
+                    {"score": 0.90, "payload": {"movie_id": "2", "title": "B",
+                      "release_year": 2001, "genres": [], "chunk_text": "b",
+                      "full_summary": "fb", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "3", "title": "C",
+                      "release_year": 2002, "genres": [], "chunk_text": "c",
+                      "full_summary": "fc", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        // Request limit=2 but pool has 3 distinct movies
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
+
+        assertThat(response.getResults()).hasSize(2);
+    }
+
+    // -------------------------------------------------------------------------
+    // Oversampling factor clamping
+    // -------------------------------------------------------------------------
+
+    @Test
+    void search_qdrantRequestLimit_isLimitTimesOversamplingFactor() {
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(5 * 20))
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        service.search(new VectorSearchRequest(VECTOR, 5));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorAbove100_clampedToDefault() {
+        VectorSearchServiceImpl svc = serviceWithFactor(150);
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(2 * 20))
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        svc.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorZero_clampedToDefault() {
+        VectorSearchServiceImpl svc = serviceWithFactor(0);
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(2 * 20))
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        svc.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorNegative_clampedToDefault() {
+        VectorSearchServiceImpl svc = serviceWithFactor(-1);
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(2 * 20))
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        svc.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorOne_usedAsIs() {
+        VectorSearchServiceImpl svc = serviceWithFactor(1);
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(5 * 1))
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        svc.search(new VectorSearchRequest(VECTOR, 5));
+
+        server.verify();
+    }
+
+    // -------------------------------------------------------------------------
+    // Exception handling
+    // -------------------------------------------------------------------------
 
     @Test
     void search_networkFailure_throwsConnectionRefusedException() {
@@ -183,19 +450,9 @@ class VectorSearchServiceImplTest {
         server.verify();
     }
 
-    @Test
-    void search_emptyResultList_returnsEmptyResponse() {
-        server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                { "result": [] }
-                """, MediaType.APPLICATION_JSON));
-
-        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
-
-        assertThat(response.getResults()).isEmpty();
-
-        server.verify();
-    }
+    // -------------------------------------------------------------------------
+    // Poster URL handling
+    // -------------------------------------------------------------------------
 
     @Test
     void search_relativeThumbnailPath_isPrefixedWithPosterBaseUrl() {
@@ -203,16 +460,9 @@ class VectorSearchServiceImplTest {
             .andRespond(withSuccess("""
                 {
                   "result": [
-                    {
-                      "score": 0.9,
-                      "payload": {
-                        "title": "Galaxy Quest",
-                        "release_year": 1999,
-                        "genres": ["Science Fiction"],
-                        "summary_snippet": "By Grabthar's hammer.",
-                        "thumbnail_url": "/poster123.jpg"
-                      }
-                    }
+                    {"score": 0.9, "payload": {"movie_id": "1", "title": "Galaxy Quest",
+                      "release_year": 1999, "genres": [], "chunk_text": "x",
+                      "full_summary": "full", "thumbnail_url": "/poster123.jpg"}}
                   ]
                 }
                 """, MediaType.APPLICATION_JSON));
@@ -221,26 +471,18 @@ class VectorSearchServiceImplTest {
 
         assertThat(response.getResults().get(0).getThumbnailUrl())
             .isEqualTo(POSTER_BASE_URL + "/poster123.jpg");
-
         server.verify();
     }
 
     @Test
-    void search_relativeThumbnailWithoutLeadingSlash_isStillJoinedCleanly() {
+    void search_relativeThumbnailWithoutLeadingSlash_isJoinedCleanly() {
         server.expect(requestTo(SEARCH_URL))
             .andRespond(withSuccess("""
                 {
                   "result": [
-                    {
-                      "score": 0.9,
-                      "payload": {
-                        "title": "Bare Path",
-                        "release_year": 2010,
-                        "genres": ["Drama"],
-                        "summary_snippet": "x",
-                        "thumbnail_url": "abc.jpg"
-                      }
-                    }
+                    {"score": 0.9, "payload": {"movie_id": "1", "title": "Bare Path",
+                      "release_year": 2010, "genres": [], "chunk_text": "x",
+                      "full_summary": "full", "thumbnail_url": "abc.jpg"}}
                   ]
                 }
                 """, MediaType.APPLICATION_JSON));
@@ -249,7 +491,6 @@ class VectorSearchServiceImplTest {
 
         assertThat(response.getResults().get(0).getThumbnailUrl())
             .isEqualTo(POSTER_BASE_URL + "/abc.jpg");
-
         server.verify();
     }
 
@@ -259,16 +500,9 @@ class VectorSearchServiceImplTest {
             .andRespond(withSuccess("""
                 {
                   "result": [
-                    {
-                      "score": 0.9,
-                      "payload": {
-                        "title": "Already Absolute",
-                        "release_year": 2020,
-                        "genres": ["Drama"],
-                        "summary_snippet": "x",
-                        "thumbnail_url": "https://other.example/img.jpg"
-                      }
-                    }
+                    {"score": 0.9, "payload": {"movie_id": "1", "title": "Already Absolute",
+                      "release_year": 2020, "genres": [], "chunk_text": "x",
+                      "full_summary": "full", "thumbnail_url": "https://other.example/img.jpg"}}
                   ]
                 }
                 """, MediaType.APPLICATION_JSON));
@@ -277,7 +511,6 @@ class VectorSearchServiceImplTest {
 
         assertThat(response.getResults().get(0).getThumbnailUrl())
             .isEqualTo("https://other.example/img.jpg");
-
         server.verify();
     }
 
@@ -293,16 +526,9 @@ class VectorSearchServiceImplTest {
             .andRespond(withSuccess("""
                 {
                   "result": [
-                    {
-                      "score": 0.9,
-                      "payload": {
-                        "title": "Trailing Slash",
-                        "release_year": 2010,
-                        "genres": ["Drama"],
-                        "summary_snippet": "x",
-                        "thumbnail_url": "/p.jpg"
-                      }
-                    }
+                    {"score": 0.9, "payload": {"movie_id": "1", "title": "Trailing Slash",
+                      "release_year": 2010, "genres": [], "chunk_text": "x",
+                      "full_summary": "full", "thumbnail_url": "/p.jpg"}}
                   ]
                 }
                 """, MediaType.APPLICATION_JSON));
@@ -311,7 +537,25 @@ class VectorSearchServiceImplTest {
 
         assertThat(response.getResults().get(0).getThumbnailUrl())
             .isEqualTo(POSTER_BASE_URL + "/p.jpg");
+        server.verify();
+    }
 
+    @Test
+    void search_nullThumbnailUrl_returnsNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.9, "payload": {"movie_id": "1", "title": "No Thumb",
+                      "release_year": 2010, "genres": [], "chunk_text": "x",
+                      "full_summary": "full", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults().get(0).getThumbnailUrl()).isNull();
         server.verify();
     }
 
@@ -326,5 +570,23 @@ class VectorSearchServiceImplTest {
         service.search(new VectorSearchRequest(VECTOR, 3));
 
         server.verify();
+    }
+
+    // -------------------------------------------------------------------------
+    // QdrantProperties defaults and validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void qdrantProperties_missingOversamplingFactor_defaultIs20() {
+        QdrantProperties props = new QdrantProperties();
+        assertThat(props.getOversamplingFactor()).isEqualTo(20);
+    }
+
+    @Test
+    void qdrantProperties_blankBaseUrl_failsValidation() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl("");
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        assertThat(validator.validate(props)).isNotEmpty();
     }
 }


### PR DESCRIPTION
## Summary

- Overhauls `VectorSearchServiceImpl` to fetch `limit × oversamplingFactor` chunks from Qdrant, group by `movie_id`, compute arithmetic mean scores, and return up to `limit` distinct movies sorted by mean score
- Adds `oversamplingFactor` to `QdrantProperties` (default 20, clamped to 1–100 at runtime)
- Adds `matchingSegment` to `MovieResult` (chunk text of highest-scoring chunk per movie)
- Implements full backwards-compat fallbacks so the service works correctly against un-migrated Qdrant data (`chunk_text`→`matchingSegment`, `full_summary`→`summarySnippet`, both falling back to `summary_snippet`)
- Adds null guards for null response body, null `result` array, null payload, null `movie_id`

## Test plan

- [ ] Run `./mvnw -f api/pom.xml test -Dtest="VectorSearchServiceImplTest,VectorSearchServiceImplIntegrationTest,MockVectorSearchServiceTest,MockSearchServiceTest"` — all 44 tests pass
- [ ] New `VectorSearchServiceImplTest` covers all 28 spec checklist items: happy path (3 chunks, 2 movies), mean pooling, oversampling factor clamping (0, -1, >100), backwards-compat fallbacks, null guards, limit enforcement, poster URL handling, exception handling, and `QdrantProperties` validation
- [ ] 14 failures in `Feature5IntegrationTest`, `QdrantPropertiesTest`, `TritonPropertiesTest`, and `SwaggerUiIntegrationTest` are pre-existing (confirmed present on `main` before this branch)

Closes #270

https://claude.ai/code/session_01EzmN4iCfikVimhhdxW9deM

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzmN4iCfikVimhhdxW9deM)_