### PR TITLE
feat(api): multi-chunk mean-pooled search for full movie summaries

### DIFF
--- a/api/src/main/java/com/moviesearch/config/QdrantProperties.java
+++ b/api/src/main/java/com/moviesearch/config/QdrantProperties.java
@@ -11,9 +11,12 @@ public class QdrantProperties {
     @NotBlank
     private String baseUrl = "http://localhost:6333";
     private boolean mock = false;
+    private int oversamplingFactor = 20;
 
     public String getBaseUrl() { return baseUrl; }
     public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
     public boolean isMock() { return mock; }
     public void setMock(boolean mock) { this.mock = mock; }
+    public int getOversamplingFactor() { return oversamplingFactor; }
+    public void setOversamplingFactor(int oversamplingFactor) { this.oversamplingFactor = oversamplingFactor; }
 }

--- a/api/src/main/java/com/moviesearch/model/MovieResult.java
+++ b/api/src/main/java/com/moviesearch/model/MovieResult.java
@@ -13,5 +13,6 @@ public class MovieResult {
     List<String> genres;
     float score;
     String summarySnippet;
+    String matchingSegment;
     String thumbnailUrl;
 }

--- a/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
@@ -24,6 +24,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "Adventure"))
             .score(0.94f)
             .summarySnippet("A FedEx executive must transform himself physically and emotionally to survive a crash landing on a deserted island.")
+            .matchingSegment("A FedEx executive crash-lands on a deserted island and must survive alone.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -32,6 +33,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.91f)
             .summarySnippet("An astronaut becomes stranded on Mars after his team assumes him dead, and must rely on his ingenuity to survive.")
+            .matchingSegment("An astronaut stranded on Mars uses science to survive until rescue.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -40,6 +42,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Thriller"))
             .score(0.88f)
             .summarySnippet("Two astronauts work together to survive after an accident leaves them stranded in space.")
+            .matchingSegment("Two astronauts struggle to return to Earth after debris destroys their shuttle.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -48,6 +51,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.85f)
             .summarySnippet("A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.")
+            .matchingSegment("Explorers travel through a wormhole seeking a new home for humanity.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -56,6 +60,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "History", "Thriller"))
             .score(0.82f)
             .summarySnippet("NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage.")
+            .matchingSegment("NASA engineers race to bring home three astronauts after an oxygen tank explosion.")
             .thumbnailUrl(null)
             .build()
     );

--- a/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
@@ -15,13 +15,20 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Service
 @ConditionalOnProperty(name = "qdrant.mock", havingValue = "false", matchIfMissing = false)
 public class VectorSearchServiceImpl implements VectorSearchService {
 
+    private static final int OVERSAMPLING_DEFAULT = 20;
+    private static final int OVERSAMPLING_MAX = 100;
+
     private final RestTemplate restTemplate;
+    private final QdrantProperties properties;
     private final String searchUrl;
     private final String posterBaseUrl;
 
@@ -29,6 +36,7 @@ public class VectorSearchServiceImpl implements VectorSearchService {
                                    QdrantProperties properties,
                                    TmdbProperties tmdbProperties) {
         this.restTemplate = restTemplate;
+        this.properties = properties;
         this.searchUrl = properties.getBaseUrl() + "/collections/movies/points/search";
         String base = tmdbProperties.getPosterBaseUrl();
         this.posterBaseUrl = base == null ? "" : base.replaceAll("/+$", "");
@@ -49,20 +57,50 @@ public class VectorSearchServiceImpl implements VectorSearchService {
 
     @Override
     public VectorSearchResponse search(VectorSearchRequest request) {
-        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit());
+        int factor = properties.getOversamplingFactor();
+        if (factor <= 0 || factor > OVERSAMPLING_MAX) {
+            factor = OVERSAMPLING_DEFAULT;
+        }
+
+        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit() * factor);
         try {
             ResponseEntity<QdrantSearchResponse> resp =
                 restTemplate.postForEntity(searchUrl, body, QdrantSearchResponse.class);
-            List<MovieResult> results = resp.getBody().result.stream()
-                .map(r -> MovieResult.builder()
-                    .title(r.payload.title)
-                    .year(r.payload.releaseYear)
-                    .genres(r.payload.genres)
-                    .score(r.score)
-                    .summarySnippet(r.payload.summarySnippet)
-                    .thumbnailUrl(absolutePosterUrl(r.payload.thumbnailUrl))
-                    .build())
+
+            QdrantSearchResponse qdrantBody = resp.getBody();
+            if (qdrantBody == null || qdrantBody.result == null) {
+                return new VectorSearchResponse(List.of());
+            }
+
+            // Group chunks by movie_id, preserving Qdrant's score-descending order within each group
+            LinkedHashMap<String, List<QdrantResult>> groups = new LinkedHashMap<>();
+            for (QdrantResult r : qdrantBody.result) {
+                if (r.payload == null || r.payload.movieId == null) continue;
+                groups.computeIfAbsent(r.payload.movieId, k -> new ArrayList<>()).add(r);
+            }
+
+            List<MovieResult> results = groups.values().stream()
+                .map(chunks -> {
+                    QdrantResult best = chunks.get(0);
+                    double meanScore = chunks.stream().mapToDouble(c -> c.score).average().orElse(0.0);
+                    String matching = best.payload.chunkText != null
+                        ? best.payload.chunkText : best.payload.summarySnippet;
+                    String summary = best.payload.fullSummary != null
+                        ? best.payload.fullSummary : best.payload.summarySnippet;
+                    return MovieResult.builder()
+                        .title(best.payload.title)
+                        .year(best.payload.releaseYear)
+                        .genres(best.payload.genres)
+                        .score((float) meanScore)
+                        .summarySnippet(summary)
+                        .matchingSegment(matching)
+                        .thumbnailUrl(absolutePosterUrl(best.payload.thumbnailUrl))
+                        .build();
+                })
+                .sorted(Comparator.comparingDouble(MovieResult::getScore).reversed())
+                .limit(request.getLimit())
                 .toList();
+
             return new VectorSearchResponse(results);
         } catch (ResourceAccessException e) {
             throw new VectorSearchServiceException(VectorSearchServiceException.CONNECTION_REFUSED, e);
@@ -93,9 +131,12 @@ public class VectorSearchServiceImpl implements VectorSearchService {
 
     static class QdrantPayload {
         public String title;
-        @JsonProperty("release_year") public Integer releaseYear;
+        @JsonProperty("release_year")    public Integer releaseYear;
         public List<String> genres;
+        @JsonProperty("movie_id")        public String movieId;
+        @JsonProperty("chunk_text")      public String chunkText;
+        @JsonProperty("full_summary")    public String fullSummary;
         @JsonProperty("summary_snippet") public String summarySnippet;
-        @JsonProperty("thumbnail_url") public String thumbnailUrl;
+        @JsonProperty("thumbnail_url")   public String thumbnailUrl;
     }
 }

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
@@ -52,8 +52,8 @@ class VectorSearchServiceImplIntegrationTest {
         String qdrantResponse = """
                 {
                   "result": [
-                    {"id":1,"score":0.94,"payload":{"title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
-                    {"id":2,"score":0.91,"payload":{"title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
+                    {"id":1,"score":0.94,"payload":{"movie_id":"111","title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
+                    {"id":2,"score":0.91,"payload":{"movie_id":"222","title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
                   ]
                 }
                 """;

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
@@ -9,6 +9,7 @@ import com.moviesearch.model.VectorSearchResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
@@ -18,6 +19,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
@@ -43,97 +45,31 @@ class VectorSearchServiceImplTest {
         service = new VectorSearchServiceImpl(restTemplate, props, tmdb);
     }
 
+    // ---- Happy path: 3 chunks, 2 movies, sorted by mean score ----
+
     @Test
-    void search_happyPath_returnsAllFieldsMapped() {
+    void search_threeChunksTwoMovies_returnsTwoResultsSortedByMeanScoreDesc() {
+        // movie "111" (Cast Away): chunks with scores 0.90 and 0.70 → mean 0.80
+        // movie "222" (Alien): chunk with score 0.85 → mean 0.85
+        // Expected order: Alien (0.85), Cast Away (0.80)
         server.expect(requestTo(SEARCH_URL))
             .andExpect(method(HttpMethod.POST))
             .andExpect(jsonPath("$.with_payload").value(true))
-            .andExpect(jsonPath("$.limit").value(5))
             .andRespond(withSuccess("""
                 {
                   "result": [
-                    {
-                      "score": 0.92,
-                      "payload": {
-                        "title": "Cast Away",
-                        "release_year": 2000,
-                        "genres": ["Drama", "Adventure"],
-                        "summary_snippet": "A FedEx executive stranded on an island.",
-                        "thumbnail_url": "https://example.com/cast-away.jpg"
-                      }
-                    }
-                  ]
-                }
-                """, MediaType.APPLICATION_JSON));
-
-        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
-
-        assertThat(response.getResults()).hasSize(1);
-        MovieResult result = response.getResults().get(0);
-        assertThat(result.getTitle()).isEqualTo("Cast Away");
-        assertThat(result.getYear()).isEqualTo(2000);
-        assertThat(result.getGenres()).containsExactly("Drama", "Adventure");
-        assertThat(result.getScore()).isEqualTo(0.92f);
-        assertThat(result.getSummarySnippet()).isEqualTo("A FedEx executive stranded on an island.");
-        assertThat(result.getThumbnailUrl()).isEqualTo("https://example.com/cast-away.jpg");
-
-        server.verify();
-    }
-
-    @Test
-    void search_nullThumbnailUrl_doesNotThrow() {
-        server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                {
-                  "result": [
-                    {
-                      "score": 0.85,
-                      "payload": {
-                        "title": "The Martian",
-                        "release_year": 2015,
-                        "genres": ["Science Fiction"],
-                        "summary_snippet": "An astronaut stranded on Mars.",
-                        "thumbnail_url": null
-                      }
-                    }
-                  ]
-                }
-                """, MediaType.APPLICATION_JSON));
-
-        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
-
-        assertThat(response.getResults()).hasSize(1);
-        assertThat(response.getResults().get(0).getThumbnailUrl()).isNull();
-
-        server.verify();
-    }
-
-    @Test
-    void search_multipleResults_allMapped() {
-        server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                {
-                  "result": [
-                    {
-                      "score": 0.92,
-                      "payload": {
-                        "title": "Movie A",
-                        "release_year": 2001,
-                        "genres": ["Action"],
-                        "summary_snippet": "Snippet A",
-                        "thumbnail_url": null
-                      }
-                    },
-                    {
-                      "score": 0.88,
-                      "payload": {
-                        "title": "Movie B",
-                        "release_year": 2002,
-                        "genres": ["Drama"],
-                        "summary_snippet": "Snippet B",
-                        "thumbnail_url": null
-                      }
-                    }
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands on an island.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He builds a raft.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space no one hears you.",
+                      "full_summary": "Full Alien summary.", "thumbnail_url": null}}
                   ]
                 }
                 """, MediaType.APPLICATION_JSON));
@@ -141,11 +77,196 @@ class VectorSearchServiceImplTest {
         VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
 
         assertThat(response.getResults()).hasSize(2);
-        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Movie A");
-        assertThat(response.getResults().get(1).getTitle()).isEqualTo("Movie B");
+        MovieResult first = response.getResults().get(0);
+        MovieResult second = response.getResults().get(1);
+        assertThat(first.getTitle()).isEqualTo("Alien");
+        assertThat(first.getScore()).isEqualTo(0.85f);
+        assertThat(second.getTitle()).isEqualTo("Cast Away");
+        assertThat(second.getScore()).isCloseTo(0.80f, within(0.001f));
 
         server.verify();
     }
+
+    // ---- QdrantSearchRequest.limit = request.getLimit() * oversamplingFactor ----
+
+    @Test
+    void search_qdrantRequestLimit_equalsLimitTimesOversamplingFactor() {
+        // default oversamplingFactor=20, limit=5 → expected Qdrant limit = 100
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(100))
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
+
+        service.search(new VectorSearchRequest(VECTOR, 5));
+
+        server.verify();
+    }
+
+    // ---- Mean score computation ----
+
+    @Test
+    void search_twoChunksSameMovie_scoreIsMeanOfBothChunkScores() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "Chunk A", "full_summary": "Summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "Chunk B", "full_summary": "Summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getScore()).isCloseTo(0.80f, within(0.001f));
+
+        server.verify();
+    }
+
+    // ---- matchingSegment: chunk_text when non-null ----
+
+    @Test
+    void search_matchingSegment_usesChunkText_whenChunkTextNonNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands on an island.",
+                      "full_summary": "Full summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults().get(0).getMatchingSegment())
+            .isEqualTo("He crash-lands on an island.");
+
+        server.verify();
+    }
+
+    // ---- matchingSegment: falls back to summary_snippet when chunk_text is null ----
+
+    @Test
+    void search_matchingSegment_fallsBackToSummarySnippet_whenChunkTextNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": null,
+                      "summary_snippet": "Old snippet for Cast Away.",
+                      "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults().get(0).getMatchingSegment())
+            .isEqualTo("Old snippet for Cast Away.");
+
+        server.verify();
+    }
+
+    // ---- summarySnippet: full_summary when non-null ----
+
+    @Test
+    void search_summarySnippet_usesFullSummary_whenFullSummaryNonNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "full_summary": "Full Cast Away summary.",
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults().get(0).getSummarySnippet())
+            .isEqualTo("Full Cast Away summary.");
+
+        server.verify();
+    }
+
+    // ---- summarySnippet: falls back to summary_snippet when full_summary is null ----
+
+    @Test
+    void search_summarySnippet_fallsBackToSummarySnippet_whenFullSummaryNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "full_summary": null,
+                      "summary_snippet": "Old snippet for Cast Away.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults().get(0).getSummarySnippet())
+            .isEqualTo("Old snippet for Cast Away.");
+
+        server.verify();
+    }
+
+    // ---- Chunk with movie_id = null is excluded ----
+
+    @Test
+    void search_nullMovieIdChunk_isExcluded_otherResultsUnaffected() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": {"movie_id": null, "title": "Ghost Movie",
+                      "release_year": 2010, "genres": ["Comedy"], "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space no one hears you.",
+                      "full_summary": "Full Alien summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Alien");
+
+        server.verify();
+    }
+
+    // ---- Empty Qdrant result ----
+
+    @Test
+    void search_emptyResultList_returnsEmptyResponse() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+
+        server.verify();
+    }
+
+    // ---- Exception handling ----
 
     @Test
     void search_networkFailure_throwsConnectionRefusedException() {
@@ -183,16 +304,260 @@ class VectorSearchServiceImplTest {
         server.verify();
     }
 
+    // ---- Result count is bounded by request.getLimit() ----
+
     @Test
-    void search_emptyResultList_returnsEmptyResponse() {
+    void search_resultCountLimitedToRequestedLimit() {
+        // Pool has 3 distinct movies but limit=2; only top 2 by mean score returned
         server.expect(requestTo(SEARCH_URL))
             .andRespond(withSuccess("""
-                { "result": [] }
+                {
+                  "result": [
+                    {"score": 0.95, "payload": {"movie_id": "1", "title": "A",
+                      "release_year": 2000, "genres": [], "thumbnail_url": null}},
+                    {"score": 0.90, "payload": {"movie_id": "2", "title": "B",
+                      "release_year": 2001, "genres": [], "thumbnail_url": null}},
+                    {"score": 0.80, "payload": {"movie_id": "3", "title": "C",
+                      "release_year": 2002, "genres": [], "thumbnail_url": null}}
+                  ]
+                }
                 """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
+
+        assertThat(response.getResults()).hasSize(2);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("A");
+        assertThat(response.getResults().get(1).getTitle()).isEqualTo("B");
+
+        server.verify();
+    }
+
+    // ---- oversamplingFactor clamping ----
+
+    @Test
+    void search_oversamplingFactorAbove100_clampsToDefault20() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(150);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(restTemplate, props, tmdb);
+
+        // limit=2, effective factor=20 → Qdrant limit = 40
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(40))
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorZero_clampsToDefault20() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(0);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(restTemplate, props, tmdb);
+
+        // limit=2, effective factor=20 → Qdrant limit = 40
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(40))
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorNegative_clampsToDefault20() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(-1);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(restTemplate, props, tmdb);
+
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(40))
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 2));
+
+        server.verify();
+    }
+
+    // ---- Null response body / null result field ----
+
+    @Test
+    void search_nullResultFieldInBody_returnsEmptyResponse() {
+        // {} → QdrantSearchResponse with result=null
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
         VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
 
         assertThat(response.getResults()).isEmpty();
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullResponseBody_returnsEmptyResponse() {
+        // 204 No Content → resp.getBody() is null
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+
+        server.verify();
+    }
+
+    // ---- Null payload chunk is skipped ----
+
+    @Test
+    void search_nullPayloadChunk_isSkipped_otherChunksAggregated() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": null},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space no one hears you.",
+                      "full_summary": "Full Alien summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Alien");
+
+        server.verify();
+    }
+
+    // ---- QdrantProperties: default oversamplingFactor is 20 ----
+
+    @Test
+    void qdrantProperties_defaultOversamplingFactor_is20() {
+        QdrantProperties props = new QdrantProperties();
+        assertThat(props.getOversamplingFactor()).isEqualTo(20);
+    }
+
+    // ---- Existing thumbnail URL tests (updated with movie_id) ----
+
+    @Test
+    void search_allFieldsMapped_oldSchemaFallback() {
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(jsonPath("$.with_payload").value(true))
+            .andExpect(jsonPath("$.limit").value(100))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {
+                      "score": 0.92,
+                      "payload": {
+                        "movie_id": "1",
+                        "title": "Cast Away",
+                        "release_year": 2000,
+                        "genres": ["Drama", "Adventure"],
+                        "summary_snippet": "A FedEx executive stranded on an island.",
+                        "thumbnail_url": "https://example.com/cast-away.jpg"
+                      }
+                    }
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        MovieResult result = response.getResults().get(0);
+        assertThat(result.getTitle()).isEqualTo("Cast Away");
+        assertThat(result.getYear()).isEqualTo(2000);
+        assertThat(result.getGenres()).containsExactly("Drama", "Adventure");
+        assertThat(result.getScore()).isEqualTo(0.92f);
+        assertThat(result.getSummarySnippet()).isEqualTo("A FedEx executive stranded on an island.");
+        assertThat(result.getMatchingSegment()).isEqualTo("A FedEx executive stranded on an island.");
+        assertThat(result.getThumbnailUrl()).isEqualTo("https://example.com/cast-away.jpg");
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullThumbnailUrl_doesNotThrow() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {
+                      "score": 0.85,
+                      "payload": {
+                        "movie_id": "1",
+                        "title": "The Martian",
+                        "release_year": 2015,
+                        "genres": ["Science Fiction"],
+                        "summary_snippet": "An astronaut stranded on Mars.",
+                        "thumbnail_url": null
+                      }
+                    }
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getThumbnailUrl()).isNull();
+
+        server.verify();
+    }
+
+    @Test
+    void search_multipleResults_allMapped() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {
+                      "score": 0.92,
+                      "payload": {
+                        "movie_id": "1",
+                        "title": "Movie A",
+                        "release_year": 2001,
+                        "genres": ["Action"],
+                        "summary_snippet": "Snippet A",
+                        "thumbnail_url": null
+                      }
+                    },
+                    {
+                      "score": 0.88,
+                      "payload": {
+                        "movie_id": "2",
+                        "title": "Movie B",
+                        "release_year": 2002,
+                        "genres": ["Drama"],
+                        "summary_snippet": "Snippet B",
+                        "thumbnail_url": null
+                      }
+                    }
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
+
+        assertThat(response.getResults()).hasSize(2);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Movie A");
+        assertThat(response.getResults().get(1).getTitle()).isEqualTo("Movie B");
 
         server.verify();
     }
@@ -206,6 +571,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Galaxy Quest",
                         "release_year": 1999,
                         "genres": ["Science Fiction"],
@@ -234,6 +600,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Bare Path",
                         "release_year": 2010,
                         "genres": ["Drama"],
@@ -262,6 +629,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Already Absolute",
                         "release_year": 2020,
                         "genres": ["Drama"],
@@ -296,6 +664,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Trailing Slash",
                         "release_year": 2010,
                         "genres": ["Drama"],


### PR DESCRIPTION
## Summary

Closes #270. Implements the API side of feature #267: oversampled multi-chunk Qdrant fetch, mean-pool aggregation by `movie_id`, and `matchingSegment` field.

- **`QdrantProperties`** — adds `oversamplingFactor` (default 20, runtime-clamped to 20 if outside 1–100)
- **`MovieResult`** — adds `matchingSegment` field (chunk text of the highest-scoring chunk per movie)
- **`VectorSearchServiceImpl`** — rewrites `search`: fetches `limit × factor` chunks, groups by `movie_id` (skips null/null-payload chunks), computes arithmetic mean score per movie, sorts descending, returns top `limit` movies. Backwards-compat fallbacks (`chunk_text → summary_snippet`, `full_summary → summary_snippet`) keep the service functional against un-migrated Qdrant data.
- **`MockVectorSearchService`** — populates `matchingSegment` on each hardcoded result
- **`VectorSearchServiceImplTest`** — replaces old tests and adds full spec coverage: happy path (3 chunks / 2 movies), mean score, `matchingSegment` / `summarySnippet` new-schema and fallback, null `movie_id` / null payload / null body / null result-field guards, oversampling-factor clamping (0, -1, >100), result-count limit enforcement

## Test plan

- [ ] `./mvnw -f api/pom.xml test -Dtest="VectorSearchServiceImplTest,VectorSearchServiceImplIntegrationTest,MockVectorSearchServiceTest,SearchControllerTest"` — all 53 tests pass
- [ ] Full suite `./mvnw -f api/pom.xml test` — only pre-existing Spring-context failures (QdrantPropertiesTest, TritonPropertiesTest, Feature5IntegrationTest, SwaggerUiIntegrationTest, EmbeddingServiceIntegrationTest); zero regressions introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4vSgFZ6in1Sfb33zLv9PG)_