### PR TITLE
feat(#270): multi-chunk mean-pooled search in VectorSearchServiceImpl

### DIFF
--- a/api/src/main/java/com/moviesearch/config/QdrantProperties.java
+++ b/api/src/main/java/com/moviesearch/config/QdrantProperties.java
@@ -11,9 +11,12 @@ public class QdrantProperties {
     @NotBlank
     private String baseUrl = "http://localhost:6333";
     private boolean mock = false;
+    private int oversamplingFactor = 20;
 
     public String getBaseUrl() { return baseUrl; }
     public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
     public boolean isMock() { return mock; }
     public void setMock(boolean mock) { this.mock = mock; }
+    public int getOversamplingFactor() { return oversamplingFactor; }
+    public void setOversamplingFactor(int oversamplingFactor) { this.oversamplingFactor = oversamplingFactor; }
 }

--- a/api/src/main/java/com/moviesearch/model/MovieResult.java
+++ b/api/src/main/java/com/moviesearch/model/MovieResult.java
@@ -13,5 +13,6 @@ public class MovieResult {
     List<String> genres;
     float score;
     String summarySnippet;
+    String matchingSegment;
     String thumbnailUrl;
 }

--- a/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
@@ -24,6 +24,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "Adventure"))
             .score(0.94f)
             .summarySnippet("A FedEx executive must transform himself physically and emotionally to survive a crash landing on a deserted island.")
+            .matchingSegment("A FedEx executive crash-lands on a deserted island.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -32,6 +33,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.91f)
             .summarySnippet("An astronaut becomes stranded on Mars after his team assumes him dead, and must rely on his ingenuity to survive.")
+            .matchingSegment("An astronaut is stranded on Mars and must rely on his ingenuity.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -40,6 +42,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Thriller"))
             .score(0.88f)
             .summarySnippet("Two astronauts work together to survive after an accident leaves them stranded in space.")
+            .matchingSegment("Two astronauts are stranded in space after a catastrophic accident.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -48,6 +51,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.85f)
             .summarySnippet("A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.")
+            .matchingSegment("Explorers travel through a wormhole to save humanity.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -56,6 +60,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "History", "Thriller"))
             .score(0.82f)
             .summarySnippet("NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage.")
+            .matchingSegment("NASA works to return the damaged Apollo 13 spacecraft safely to Earth.")
             .thumbnailUrl(null)
             .build()
     );

--- a/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
@@ -15,20 +15,28 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @ConditionalOnProperty(name = "qdrant.mock", havingValue = "false", matchIfMissing = false)
 public class VectorSearchServiceImpl implements VectorSearchService {
 
+    private static final int OVERSAMPLING_DEFAULT = 20;
+    private static final int OVERSAMPLING_MAX = 100;
+
     private final RestTemplate restTemplate;
     private final String searchUrl;
     private final String posterBaseUrl;
+    private final QdrantProperties properties;
 
     public VectorSearchServiceImpl(RestTemplate restTemplate,
                                    QdrantProperties properties,
                                    TmdbProperties tmdbProperties) {
         this.restTemplate = restTemplate;
+        this.properties = properties;
         this.searchUrl = properties.getBaseUrl() + "/collections/movies/points/search";
         String base = tmdbProperties.getPosterBaseUrl();
         this.posterBaseUrl = base == null ? "" : base.replaceAll("/+$", "");
@@ -49,21 +57,65 @@ public class VectorSearchServiceImpl implements VectorSearchService {
 
     @Override
     public VectorSearchResponse search(VectorSearchRequest request) {
-        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit());
+        int factor = properties.getOversamplingFactor();
+        if (factor <= 0 || factor > OVERSAMPLING_MAX) {
+            factor = OVERSAMPLING_DEFAULT;
+        }
+
+        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit() * factor);
         try {
             ResponseEntity<QdrantSearchResponse> resp =
                 restTemplate.postForEntity(searchUrl, body, QdrantSearchResponse.class);
-            List<MovieResult> results = resp.getBody().result.stream()
-                .map(r -> MovieResult.builder()
-                    .title(r.payload.title)
-                    .year(r.payload.releaseYear)
-                    .genres(r.payload.genres)
-                    .score(r.score)
-                    .summarySnippet(r.payload.summarySnippet)
-                    .thumbnailUrl(absolutePosterUrl(r.payload.thumbnailUrl))
-                    .build())
-                .toList();
-            return new VectorSearchResponse(results);
+
+            QdrantSearchResponse responseBody = resp.getBody();
+            if (responseBody == null || responseBody.result == null) {
+                return new VectorSearchResponse(List.of());
+            }
+
+            // Group chunks by movie_id; skip chunks with null payload or null movie_id
+            Map<String, List<QdrantResult>> grouped = new LinkedHashMap<>();
+            for (QdrantResult r : responseBody.result) {
+                if (r.payload == null || r.payload.movieId == null) {
+                    continue;
+                }
+                grouped.computeIfAbsent(r.payload.movieId, k -> new ArrayList<>()).add(r);
+            }
+
+            // Aggregate each group: mean score, best chunk = first in group (highest Qdrant score)
+            List<MovieResult> movies = new ArrayList<>();
+            for (List<QdrantResult> chunks : grouped.values()) {
+                QdrantResult best = chunks.get(0);
+                double sum = 0.0;
+                for (QdrantResult c : chunks) {
+                    sum += c.score;
+                }
+                float meanScore = (float) (sum / chunks.size());
+
+                String matching = best.payload.chunkText != null
+                    ? best.payload.chunkText
+                    : best.payload.summarySnippet;
+                String summary = best.payload.fullSummary != null
+                    ? best.payload.fullSummary
+                    : best.payload.summarySnippet;
+
+                movies.add(MovieResult.builder()
+                    .title(best.payload.title)
+                    .year(best.payload.releaseYear)
+                    .genres(best.payload.genres)
+                    .score(meanScore)
+                    .summarySnippet(summary)
+                    .matchingSegment(matching)
+                    .thumbnailUrl(absolutePosterUrl(best.payload.thumbnailUrl))
+                    .build());
+            }
+
+            // Sort descending by mean score, then take up to limit
+            movies.sort((a, b) -> Float.compare(b.getScore(), a.getScore()));
+            if (movies.size() > request.getLimit()) {
+                movies = movies.subList(0, request.getLimit());
+            }
+
+            return new VectorSearchResponse(movies);
         } catch (ResourceAccessException e) {
             throw new VectorSearchServiceException(VectorSearchServiceException.CONNECTION_REFUSED, e);
         } catch (HttpStatusCodeException e) {
@@ -92,10 +144,13 @@ public class VectorSearchServiceImpl implements VectorSearchService {
     }
 
     static class QdrantPayload {
+        @JsonProperty("movie_id")       public String movieId;
         public String title;
-        @JsonProperty("release_year") public Integer releaseYear;
+        @JsonProperty("release_year")   public Integer releaseYear;
         public List<String> genres;
+        @JsonProperty("chunk_text")     public String chunkText;
+        @JsonProperty("full_summary")   public String fullSummary;
         @JsonProperty("summary_snippet") public String summarySnippet;
-        @JsonProperty("thumbnail_url") public String thumbnailUrl;
+        @JsonProperty("thumbnail_url")  public String thumbnailUrl;
     }
 }

--- a/api/src/test/java/com/moviesearch/config/QdrantPropertiesTest.java
+++ b/api/src/test/java/com/moviesearch/config/QdrantPropertiesTest.java
@@ -21,4 +21,9 @@ class QdrantPropertiesTest {
     void defaultMockIsFalse() {
         assertThat(qdrantProperties.isMock()).isFalse();
     }
+
+    @Test
+    void defaultOversamplingFactorIs20() {
+        assertThat(qdrantProperties.getOversamplingFactor()).isEqualTo(20);
+    }
 }

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
@@ -52,8 +52,8 @@ class VectorSearchServiceImplIntegrationTest {
         String qdrantResponse = """
                 {
                   "result": [
-                    {"id":1,"score":0.94,"payload":{"title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
-                    {"id":2,"score":0.91,"payload":{"title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
+                    {"id":1,"score":0.94,"payload":{"movie_id":"1","title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
+                    {"id":2,"score":0.91,"payload":{"movie_id":"2","title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
                   ]
                 }
                 """;

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
@@ -43,97 +44,34 @@ class VectorSearchServiceImplTest {
         service = new VectorSearchServiceImpl(restTemplate, props, tmdb);
     }
 
+    // -----------------------------------------------------------------------
+    // Multi-chunk aggregation (spec happy path)
+    // -----------------------------------------------------------------------
+
     @Test
-    void search_happyPath_returnsAllFieldsMapped() {
+    void search_multiChunk_twoMoviesThreeChunks_returnsTwoResultsSortedByMeanScore() {
+        // movie "111" has 2 chunks (scores 0.90, 0.70 → mean 0.80)
+        // movie "222" has 1 chunk  (score  0.85           → mean 0.85)
+        // sorted desc: "222" (0.85), "111" (0.80)
         server.expect(requestTo(SEARCH_URL))
             .andExpect(method(HttpMethod.POST))
             .andExpect(jsonPath("$.with_payload").value(true))
-            .andExpect(jsonPath("$.limit").value(5))
+            .andExpect(jsonPath("$.limit").value(2 * 20))
             .andRespond(withSuccess("""
                 {
                   "result": [
-                    {
-                      "score": 0.92,
-                      "payload": {
-                        "title": "Cast Away",
-                        "release_year": 2000,
-                        "genres": ["Drama", "Adventure"],
-                        "summary_snippet": "A FedEx executive stranded on an island.",
-                        "thumbnail_url": "https://example.com/cast-away.jpg"
-                      }
-                    }
-                  ]
-                }
-                """, MediaType.APPLICATION_JSON));
-
-        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
-
-        assertThat(response.getResults()).hasSize(1);
-        MovieResult result = response.getResults().get(0);
-        assertThat(result.getTitle()).isEqualTo("Cast Away");
-        assertThat(result.getYear()).isEqualTo(2000);
-        assertThat(result.getGenres()).containsExactly("Drama", "Adventure");
-        assertThat(result.getScore()).isEqualTo(0.92f);
-        assertThat(result.getSummarySnippet()).isEqualTo("A FedEx executive stranded on an island.");
-        assertThat(result.getThumbnailUrl()).isEqualTo("https://example.com/cast-away.jpg");
-
-        server.verify();
-    }
-
-    @Test
-    void search_nullThumbnailUrl_doesNotThrow() {
-        server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                {
-                  "result": [
-                    {
-                      "score": 0.85,
-                      "payload": {
-                        "title": "The Martian",
-                        "release_year": 2015,
-                        "genres": ["Science Fiction"],
-                        "summary_snippet": "An astronaut stranded on Mars.",
-                        "thumbnail_url": null
-                      }
-                    }
-                  ]
-                }
-                """, MediaType.APPLICATION_JSON));
-
-        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
-
-        assertThat(response.getResults()).hasSize(1);
-        assertThat(response.getResults().get(0).getThumbnailUrl()).isNull();
-
-        server.verify();
-    }
-
-    @Test
-    void search_multipleResults_allMapped() {
-        server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                {
-                  "result": [
-                    {
-                      "score": 0.92,
-                      "payload": {
-                        "title": "Movie A",
-                        "release_year": 2001,
-                        "genres": ["Action"],
-                        "summary_snippet": "Snippet A",
-                        "thumbnail_url": null
-                      }
-                    },
-                    {
-                      "score": 0.88,
-                      "payload": {
-                        "title": "Movie B",
-                        "release_year": 2002,
-                        "genres": ["Drama"],
-                        "summary_snippet": "Snippet B",
-                        "thumbnail_url": null
-                      }
-                    }
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands on an island.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He builds a raft.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space no one hears you.",
+                      "full_summary": "Full Alien summary.", "thumbnail_url": null}}
                   ]
                 }
                 """, MediaType.APPLICATION_JSON));
@@ -141,11 +79,297 @@ class VectorSearchServiceImplTest {
         VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
 
         assertThat(response.getResults()).hasSize(2);
-        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Movie A");
-        assertThat(response.getResults().get(1).getTitle()).isEqualTo("Movie B");
+        // Alien ranked first (mean 0.85 > 0.80)
+        MovieResult alien = response.getResults().get(0);
+        assertThat(alien.getTitle()).isEqualTo("Alien");
+        assertThat(alien.getScore()).isEqualTo(0.85f);
+        assertThat(alien.getMatchingSegment()).isEqualTo("In space no one hears you.");
+        assertThat(alien.getSummarySnippet()).isEqualTo("Full Alien summary.");
+
+        MovieResult castAway = response.getResults().get(1);
+        assertThat(castAway.getTitle()).isEqualTo("Cast Away");
+        assertThat(castAway.getScore()).isCloseTo(0.80f, within(0.001f));
+        assertThat(castAway.getMatchingSegment()).isEqualTo("He crash-lands on an island.");
+        assertThat(castAway.getSummarySnippet()).isEqualTo("Full Cast Away summary.");
 
         server.verify();
     }
+
+    @Test
+    void search_qdrantRequestLimit_equalsRequestLimitTimesOversamplingFactor() {
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(5 * 20))
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
+
+        service.search(new VectorSearchRequest(VECTOR, 5));
+
+        server.verify();
+    }
+
+    @Test
+    void search_twoChunksSameMovie_scoreIsArithmeticMean() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "Chunk one.", "full_summary": "Full summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "Chunk two.", "full_summary": "Full summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getScore()).isCloseTo(0.80f, within(0.001f));
+    }
+
+    @Test
+    void search_matchingSegment_isChunkTextOfHighestScoringChunk() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": "Best chunk.", "full_summary": "Full.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": "Lower chunk.", "full_summary": "Full.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getMatchingSegment()).isEqualTo("Best chunk.");
+    }
+
+    @Test
+    void search_oldSchema_matchingSegmentFallsBackToSummarySnippet() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.80, "payload": {"movie_id": "111", "title": "Old Movie",
+                      "release_year": 2000, "genres": [],
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getMatchingSegment()).isEqualTo("Old snippet.");
+    }
+
+    @Test
+    void search_newSchema_summarySnippetIsFullSummary() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.80, "payload": {"movie_id": "111", "title": "Movie",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": "A chunk.", "full_summary": "The full summary text.",
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getSummarySnippet()).isEqualTo("The full summary text.");
+    }
+
+    @Test
+    void search_oldSchema_summarySnippetFallsBackToSummarySnippetField() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.80, "payload": {"movie_id": "111", "title": "Old Movie",
+                      "release_year": 2000, "genres": [],
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults().get(0).getSummarySnippet()).isEqualTo("Old snippet.");
+    }
+
+    @Test
+    void search_chunkWithNullMovieId_isExcluded() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": {"movie_id": null, "title": "Ghost Movie",
+                      "release_year": 2010, "genres": [], "thumbnail_url": null}},
+                    {"score": 0.80, "payload": {"movie_id": "222", "title": "Real Movie",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": "Real chunk.", "full_summary": "Real summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Real Movie");
+    }
+
+    @Test
+    void search_resultCountCappedAtRequestLimit() {
+        // 3 distinct movies returned, but limit=2
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "A", "title": "Alpha",
+                      "release_year": 2001, "genres": [], "chunk_text": "c", "full_summary": "f", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "B", "title": "Beta",
+                      "release_year": 2002, "genres": [], "chunk_text": "c", "full_summary": "f", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "C", "title": "Gamma",
+                      "release_year": 2003, "genres": [], "chunk_text": "c", "full_summary": "f", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
+
+        assertThat(response.getResults()).hasSize(2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Oversampling factor clamping
+    // -----------------------------------------------------------------------
+
+    @Test
+    void search_oversamplingFactorAbove100_isClampedToDefault20() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(150);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(restTemplate, props, tmdb);
+
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(3 * 20))
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 3));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorZero_isClampedToDefault20() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(0);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(restTemplate, props, tmdb);
+
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(3 * 20))
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 3));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactorNegative_isClampedToDefault20() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(-1);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(restTemplate, props, tmdb);
+
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(3 * 20))
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 3));
+
+        server.verify();
+    }
+
+    @Test
+    void search_oversamplingFactor1_fetchesLimitTimes1() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(1);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(restTemplate, props, tmdb);
+
+        server.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(5 * 1))
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 5));
+
+        server.verify();
+    }
+
+    // -----------------------------------------------------------------------
+    // Null safety
+    // -----------------------------------------------------------------------
+
+    @Test
+    void search_nullResponseBody_returnsEmptyResponse() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("", MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+    }
+
+    @Test
+    void search_nullResultField_returnsEmptyResponse() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("{\"result\":null}", MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+    }
+
+    @Test
+    void search_chunkWithNullPayload_isSkippedSilently() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": null},
+                    {"score": 0.80, "payload": {"movie_id": "222", "title": "Real Movie",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": "Real chunk.", "full_summary": "Real summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Real Movie");
+    }
+
+    // -----------------------------------------------------------------------
+    // Error handling
+    // -----------------------------------------------------------------------
 
     @Test
     void search_networkFailure_throwsConnectionRefusedException() {
@@ -186,13 +410,44 @@ class VectorSearchServiceImplTest {
     @Test
     void search_emptyResultList_returnsEmptyResponse() {
         server.expect(requestTo(SEARCH_URL))
-            .andRespond(withSuccess("""
-                { "result": [] }
-                """, MediaType.APPLICATION_JSON));
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
 
         VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
 
         assertThat(response.getResults()).isEmpty();
+
+        server.verify();
+    }
+
+    // -----------------------------------------------------------------------
+    // Thumbnail URL handling
+    // -----------------------------------------------------------------------
+
+    @Test
+    void search_nullThumbnailUrl_doesNotThrow() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {
+                      "score": 0.85,
+                      "payload": {
+                        "movie_id": "1",
+                        "title": "The Martian",
+                        "release_year": 2015,
+                        "genres": ["Science Fiction"],
+                        "summary_snippet": "An astronaut stranded on Mars.",
+                        "thumbnail_url": null
+                      }
+                    }
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getThumbnailUrl()).isNull();
 
         server.verify();
     }
@@ -206,6 +461,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Galaxy Quest",
                         "release_year": 1999,
                         "genres": ["Science Fiction"],
@@ -234,6 +490,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Bare Path",
                         "release_year": 2010,
                         "genres": ["Drama"],
@@ -262,6 +519,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Already Absolute",
                         "release_year": 2020,
                         "genres": ["Drama"],
@@ -296,6 +554,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "1",
                         "title": "Trailing Slash",
                         "release_year": 2010,
                         "genres": ["Drama"],
@@ -319,9 +578,7 @@ class VectorSearchServiceImplTest {
     void search_sendsWithPayloadTrue() {
         server.expect(requestTo(SEARCH_URL))
             .andExpect(jsonPath("$.with_payload").value(true))
-            .andRespond(withSuccess("""
-                { "result": [] }
-                """, MediaType.APPLICATION_JSON));
+            .andRespond(withSuccess("{\"result\":[]}", MediaType.APPLICATION_JSON));
 
         service.search(new VectorSearchRequest(VECTOR, 3));
 


### PR DESCRIPTION
## Summary

Closes #270. Implements oversampled multi-chunk Qdrant search with mean-pool aggregation and backwards-compatible fallbacks.

- **`QdrantProperties`** — adds `oversamplingFactor` field (default 20, config key `qdrant.oversampling-factor`); values outside 1–100 are clamped to 20 at runtime
- **`MovieResult`** — adds `matchingSegment` field (chunk text of highest-scoring chunk per movie)
- **`VectorSearchServiceImpl`** — rewrites `search`: fetches `limit × factor` chunks, groups by `movie_id`, computes arithmetic mean score per movie, sorts descending, returns top `limit` movies; null payload/null `movie_id` chunks are silently skipped; null response body and null result array return empty results; backwards-compat fallbacks read `summary_snippet` when `chunk_text`/`full_summary` are absent (old-schema Qdrant data)
- **`MockVectorSearchService`** — all five mock results now populate `matchingSegment`
- **Tests** — `VectorSearchServiceImplTest` expanded from 10 to 26 tests covering all spec checklist items; integration test updated to include `movie_id` in Qdrant payloads; `QdrantPropertiesTest` gains default-value assertion for `oversamplingFactor`

## Test plan

- [x] `./mvnw -f api/pom.xml test -Dtest="VectorSearchServiceImplTest,VectorSearchServiceImplIntegrationTest,MockVectorSearchServiceTest"` → 36 tests, BUILD SUCCESS
- [x] Multi-chunk mean-pool: 3 chunks across 2 movies → 2 results sorted by mean score desc
- [x] Oversampling factor clamping: 150, 0, -1 all clamp to 20
- [x] Old-schema fallback: `matchingSegment` and `summarySnippet` fall back to `summary_snippet`
- [x] Null safety: null body, null result, null payload, null movie_id all handled without exception

https://claude.ai/code/session_01Sn9qbMWzEnv4gHu2VwL7ra

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sn9qbMWzEnv4gHu2VwL7ra)_