### PR TITLE
Multi-chunk mean-pooled search for VectorSearchServiceImpl (#270)

### DIFF
--- a/api/src/main/java/com/moviesearch/config/QdrantProperties.java
+++ b/api/src/main/java/com/moviesearch/config/QdrantProperties.java
@@ -11,9 +11,12 @@ public class QdrantProperties {
     @NotBlank
     private String baseUrl = "http://localhost:6333";
     private boolean mock = false;
+    private int oversamplingFactor = 20;
 
     public String getBaseUrl() { return baseUrl; }
     public void setBaseUrl(String baseUrl) { this.baseUrl = baseUrl; }
     public boolean isMock() { return mock; }
     public void setMock(boolean mock) { this.mock = mock; }
+    public int getOversamplingFactor() { return oversamplingFactor; }
+    public void setOversamplingFactor(int oversamplingFactor) { this.oversamplingFactor = oversamplingFactor; }
 }

--- a/api/src/main/java/com/moviesearch/model/MovieResult.java
+++ b/api/src/main/java/com/moviesearch/model/MovieResult.java
@@ -13,5 +13,6 @@ public class MovieResult {
     List<String> genres;
     float score;
     String summarySnippet;
+    String matchingSegment;
     String thumbnailUrl;
 }

--- a/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
+++ b/api/src/main/java/com/moviesearch/service/impl/MockVectorSearchService.java
@@ -24,6 +24,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "Adventure"))
             .score(0.94f)
             .summarySnippet("A FedEx executive must transform himself physically and emotionally to survive a crash landing on a deserted island.")
+            .matchingSegment("A FedEx executive must transform himself physically and emotionally to survive a crash landing on a deserted island.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -32,6 +33,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.91f)
             .summarySnippet("An astronaut becomes stranded on Mars after his team assumes him dead, and must rely on his ingenuity to survive.")
+            .matchingSegment("An astronaut becomes stranded on Mars after his team assumes him dead, and must rely on his ingenuity to survive.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -40,6 +42,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Thriller"))
             .score(0.88f)
             .summarySnippet("Two astronauts work together to survive after an accident leaves them stranded in space.")
+            .matchingSegment("Two astronauts work together to survive after an accident leaves them stranded in space.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -48,6 +51,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Science Fiction", "Adventure", "Drama"))
             .score(0.85f)
             .summarySnippet("A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.")
+            .matchingSegment("A team of explorers travel through a wormhole in space in an attempt to ensure humanity's survival.")
             .thumbnailUrl(null)
             .build(),
         MovieResult.builder()
@@ -56,6 +60,7 @@ public class MockVectorSearchService implements VectorSearchService {
             .genres(List.of("Drama", "History", "Thriller"))
             .score(0.82f)
             .summarySnippet("NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage.")
+            .matchingSegment("NASA must devise a strategy to return Apollo 13 to Earth safely after the spacecraft undergoes massive internal damage.")
             .thumbnailUrl(null)
             .build()
     );

--- a/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
+++ b/api/src/main/java/com/moviesearch/service/impl/VectorSearchServiceImpl.java
@@ -15,13 +15,19 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Service
 @ConditionalOnProperty(name = "qdrant.mock", havingValue = "false", matchIfMissing = false)
 public class VectorSearchServiceImpl implements VectorSearchService {
 
+    private static final int OVERSAMPLING_DEFAULT = 20;
+    private static final int OVERSAMPLING_MAX = 100;
+
     private final RestTemplate restTemplate;
+    private final QdrantProperties properties;
     private final String searchUrl;
     private final String posterBaseUrl;
 
@@ -29,6 +35,7 @@ public class VectorSearchServiceImpl implements VectorSearchService {
                                    QdrantProperties properties,
                                    TmdbProperties tmdbProperties) {
         this.restTemplate = restTemplate;
+        this.properties = properties;
         this.searchUrl = properties.getBaseUrl() + "/collections/movies/points/search";
         String base = tmdbProperties.getPosterBaseUrl();
         this.posterBaseUrl = base == null ? "" : base.replaceAll("/+$", "");
@@ -49,20 +56,58 @@ public class VectorSearchServiceImpl implements VectorSearchService {
 
     @Override
     public VectorSearchResponse search(VectorSearchRequest request) {
-        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit());
+        int factor = properties.getOversamplingFactor();
+        if (factor <= 0 || factor > OVERSAMPLING_MAX) {
+            factor = OVERSAMPLING_DEFAULT;
+        }
+
+        QdrantSearchRequest body = new QdrantSearchRequest(request.getVector(), request.getLimit() * factor);
         try {
             ResponseEntity<QdrantSearchResponse> resp =
                 restTemplate.postForEntity(searchUrl, body, QdrantSearchResponse.class);
-            List<MovieResult> results = resp.getBody().result.stream()
-                .map(r -> MovieResult.builder()
-                    .title(r.payload.title)
-                    .year(r.payload.releaseYear)
-                    .genres(r.payload.genres)
-                    .score(r.score)
-                    .summarySnippet(r.payload.summarySnippet)
-                    .thumbnailUrl(absolutePosterUrl(r.payload.thumbnailUrl))
-                    .build())
+
+            QdrantSearchResponse qdrantBody = resp.getBody();
+            if (qdrantBody == null || qdrantBody.result == null) {
+                return new VectorSearchResponse(List.of());
+            }
+
+            // Group by movie_id preserving insertion order; Qdrant returns by score desc,
+            // so the first chunk per group is the highest-scoring one.
+            LinkedHashMap<String, List<QdrantResult>> groups = new LinkedHashMap<>();
+            for (QdrantResult r : qdrantBody.result) {
+                if (r.payload == null || r.payload.movieId == null) continue;
+                groups.computeIfAbsent(r.payload.movieId, k -> new ArrayList<>()).add(r);
+            }
+
+            List<MovieResult> results = groups.values().stream()
+                .map(chunks -> {
+                    QdrantResult best = chunks.get(0);
+                    float meanScore = (float) chunks.stream()
+                        .mapToDouble(c -> c.score)
+                        .average()
+                        .orElse(0.0);
+
+                    String matching = best.payload.chunkText != null
+                        ? best.payload.chunkText
+                        : best.payload.summarySnippet;
+                    String summary = best.payload.fullSummary != null
+                        ? best.payload.fullSummary
+                        : best.payload.summarySnippet;
+
+                    return MovieResult.builder()
+                        .title(best.payload.title)
+                        .year(best.payload.releaseYear)
+                        .genres(best.payload.genres)
+                        .score(meanScore)
+                        .summarySnippet(summary)
+                        .matchingSegment(matching)
+                        .thumbnailUrl(absolutePosterUrl(best.payload.thumbnailUrl))
+                        .build();
+                })
+                .sorted((a, b) -> Float.compare(b.getScore(), a.getScore()))
+                .limit(request.getLimit())
                 .toList();
+
             return new VectorSearchResponse(results);
         } catch (ResourceAccessException e) {
             throw new VectorSearchServiceException(VectorSearchServiceException.CONNECTION_REFUSED, e);
@@ -92,10 +137,13 @@ public class VectorSearchServiceImpl implements VectorSearchService {
     }
 
     static class QdrantPayload {
+        @JsonProperty("movie_id") public String movieId;
         public String title;
         @JsonProperty("release_year") public Integer releaseYear;
         public List<String> genres;
         @JsonProperty("summary_snippet") public String summarySnippet;
+        @JsonProperty("chunk_text") public String chunkText;
+        @JsonProperty("full_summary") public String fullSummary;
         @JsonProperty("thumbnail_url") public String thumbnailUrl;
     }
 }

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplIntegrationTest.java
@@ -52,8 +52,8 @@ class VectorSearchServiceImplIntegrationTest {
         String qdrantResponse = """
                 {
                   "result": [
-                    {"id":1,"score":0.94,"payload":{"title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
-                    {"id":2,"score":0.91,"payload":{"title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
+                    {"id":1,"score":0.94,"payload":{"movie_id":"111","title":"Cast Away","release_year":2000,"genres":["Drama","Adventure"],"summary_snippet":"A FedEx executive must survive a crash landing.","thumbnail_url":"https://image.tmdb.org/t/p/w200/path.jpg"}},
+                    {"id":2,"score":0.91,"payload":{"movie_id":"222","title":"The Martian","release_year":2015,"genres":["Science Fiction"],"summary_snippet":"An astronaut stranded on Mars.","thumbnail_url":null}}
                   ]
                 }
                 """;

--- a/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
+++ b/api/src/test/java/com/moviesearch/service/impl/VectorSearchServiceImplTest.java
@@ -8,8 +8,10 @@ import com.moviesearch.model.VectorSearchRequest;
 import com.moviesearch.model.VectorSearchResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
@@ -18,6 +20,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
@@ -43,18 +49,21 @@ class VectorSearchServiceImplTest {
         service = new VectorSearchServiceImpl(restTemplate, props, tmdb);
     }
 
+    // ── Existing tests (updated for new schema) ──────────────────────────────
+
     @Test
     void search_happyPath_returnsAllFieldsMapped() {
         server.expect(requestTo(SEARCH_URL))
             .andExpect(method(HttpMethod.POST))
             .andExpect(jsonPath("$.with_payload").value(true))
-            .andExpect(jsonPath("$.limit").value(5))
+            .andExpect(jsonPath("$.limit").value(100)) // 5 * default oversamplingFactor(20)
             .andRespond(withSuccess("""
                 {
                   "result": [
                     {
                       "score": 0.92,
                       "payload": {
+                        "movie_id": "m1",
                         "title": "Cast Away",
                         "release_year": 2000,
                         "genres": ["Drama", "Adventure"],
@@ -74,7 +83,10 @@ class VectorSearchServiceImplTest {
         assertThat(result.getYear()).isEqualTo(2000);
         assertThat(result.getGenres()).containsExactly("Drama", "Adventure");
         assertThat(result.getScore()).isEqualTo(0.92f);
+        // old-schema fallback: no full_summary → summarySnippet from summary_snippet
         assertThat(result.getSummarySnippet()).isEqualTo("A FedEx executive stranded on an island.");
+        // old-schema fallback: no chunk_text → matchingSegment from summary_snippet
+        assertThat(result.getMatchingSegment()).isEqualTo("A FedEx executive stranded on an island.");
         assertThat(result.getThumbnailUrl()).isEqualTo("https://example.com/cast-away.jpg");
 
         server.verify();
@@ -89,6 +101,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.85,
                       "payload": {
+                        "movie_id": "m1",
                         "title": "The Martian",
                         "release_year": 2015,
                         "genres": ["Science Fiction"],
@@ -117,6 +130,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.92,
                       "payload": {
+                        "movie_id": "ma",
                         "title": "Movie A",
                         "release_year": 2001,
                         "genres": ["Action"],
@@ -127,6 +141,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.88,
                       "payload": {
+                        "movie_id": "mb",
                         "title": "Movie B",
                         "release_year": 2002,
                         "genres": ["Drama"],
@@ -206,6 +221,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "m1",
                         "title": "Galaxy Quest",
                         "release_year": 1999,
                         "genres": ["Science Fiction"],
@@ -234,6 +250,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "m1",
                         "title": "Bare Path",
                         "release_year": 2010,
                         "genres": ["Drama"],
@@ -262,6 +279,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "m1",
                         "title": "Already Absolute",
                         "release_year": 2020,
                         "genres": ["Drama"],
@@ -296,6 +314,7 @@ class VectorSearchServiceImplTest {
                     {
                       "score": 0.9,
                       "payload": {
+                        "movie_id": "m1",
                         "title": "Trailing Slash",
                         "release_year": 2010,
                         "genres": ["Drama"],
@@ -326,5 +345,310 @@ class VectorSearchServiceImplTest {
         service.search(new VectorSearchRequest(VECTOR, 3));
 
         server.verify();
+    }
+
+    // ── New tests: multi-chunk aggregation ───────────────────────────────────
+
+    @Test
+    void search_multiChunk_twoMovies_returnsMeanPooledResultsInScoreOrder() {
+        // Movie "111": 2 chunks (0.90, 0.70) → mean 0.80
+        // Movie "222": 1 chunk (0.85) → mean 0.85
+        // Expected order: Alien (0.85) then Cast Away (0.80)
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.90, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He crash-lands on an island.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.70, "payload": {"movie_id": "111", "title": "Cast Away",
+                      "release_year": 2000, "genres": ["Drama"],
+                      "chunk_text": "He builds a raft.",
+                      "full_summary": "Full Cast Away summary.", "thumbnail_url": null}},
+                    {"score": 0.85, "payload": {"movie_id": "222", "title": "Alien",
+                      "release_year": 1979, "genres": ["Sci-Fi"],
+                      "chunk_text": "In space no one hears you.",
+                      "full_summary": "Full Alien summary.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
+
+        List<MovieResult> results = response.getResults();
+        assertThat(results).hasSize(2);
+
+        MovieResult alien = results.get(0);
+        assertThat(alien.getTitle()).isEqualTo("Alien");
+        assertThat(alien.getScore()).isCloseTo(0.85f, within(0.001f));
+        assertThat(alien.getMatchingSegment()).isEqualTo("In space no one hears you.");
+        assertThat(alien.getSummarySnippet()).isEqualTo("Full Alien summary.");
+
+        MovieResult castAway = results.get(1);
+        assertThat(castAway.getTitle()).isEqualTo("Cast Away");
+        assertThat(castAway.getScore()).isCloseTo(0.80f, within(0.001f));
+        // matchingSegment = highest-scoring chunk = first chunk inserted (0.90)
+        assertThat(castAway.getMatchingSegment()).isEqualTo("He crash-lands on an island.");
+        assertThat(castAway.getSummarySnippet()).isEqualTo("Full Cast Away summary.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_limitSentToQdrant_equalsRequestLimitTimesOversamplingFactor() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(3);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        RestTemplate rt = new RestTemplate();
+        MockRestServiceServer localServer = MockRestServiceServer.createServer(rt);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(rt, props, tmdb);
+
+        localServer.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(15)) // 5 * 3
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 5));
+
+        localServer.verify();
+    }
+
+    @Test
+    void search_chunkText_usedAsMatchingSegment_whenPresent() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.9, "payload": {"movie_id": "1", "title": "T",
+                      "release_year": 2000, "genres": [],
+                      "chunk_text": "The chunk text.", "full_summary": "The full summary.",
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+        MovieResult result = response.getResults().get(0);
+
+        assertThat(result.getMatchingSegment()).isEqualTo("The chunk text.");
+        assertThat(result.getSummarySnippet()).isEqualTo("The full summary.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_matchingSegment_fallsBackToSummarySnippet_whenChunkTextNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.9, "payload": {"movie_id": "1", "title": "T",
+                      "release_year": 2000, "genres": [],
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults().get(0).getMatchingSegment()).isEqualTo("Old snippet.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_summarySnippet_fallsBackToSummarySnippetField_whenFullSummaryNull() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.9, "payload": {"movie_id": "1", "title": "T",
+                      "release_year": 2000, "genres": [],
+                      "summary_snippet": "Old snippet.", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 1));
+
+        assertThat(response.getResults().get(0).getSummarySnippet()).isEqualTo("Old snippet.");
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullMovieId_chunkExcluded_otherResultsUnaffected() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": {"movie_id": null, "title": "Ghost",
+                      "release_year": 2000, "genres": [], "thumbnail_url": null}},
+                    {"score": 0.80, "payload": {"movie_id": "valid", "title": "Valid Movie",
+                      "release_year": 2010, "genres": [], "summary_snippet": "s", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Valid Movie");
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullPayload_chunkSkipped_otherResultsUnaffected() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.95, "payload": null},
+                    {"score": 0.80, "payload": {"movie_id": "valid", "title": "Valid Movie",
+                      "release_year": 2010, "genres": [], "summary_snippet": "s", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getTitle()).isEqualTo("Valid Movie");
+
+        server.verify();
+    }
+
+    @Test
+    void search_resultCount_limitedToRequestLimit() {
+        // Pool returns 3 distinct movies but limit=2; only 2 should be returned
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                {
+                  "result": [
+                    {"score": 0.9, "payload": {"movie_id": "a", "title": "A",
+                      "release_year": 2000, "genres": [], "summary_snippet": "s", "thumbnail_url": null}},
+                    {"score": 0.8, "payload": {"movie_id": "b", "title": "B",
+                      "release_year": 2001, "genres": [], "summary_snippet": "s", "thumbnail_url": null}},
+                    {"score": 0.7, "payload": {"movie_id": "c", "title": "C",
+                      "release_year": 2002, "genres": [], "summary_snippet": "s", "thumbnail_url": null}}
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 2));
+
+        assertThat(response.getResults()).hasSize(2);
+
+        server.verify();
+    }
+
+    @Test
+    void search_nullResultInBody_returnsEmptyResponse() {
+        server.expect(requestTo(SEARCH_URL))
+            .andRespond(withSuccess("""
+                { "result": null }
+                """, MediaType.APPLICATION_JSON));
+
+        VectorSearchResponse response = service.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+
+        server.verify();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void search_nullResponseBody_returnsEmptyResponse() {
+        RestTemplate mockRest = Mockito.mock(RestTemplate.class);
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(mockRest, props, tmdb);
+
+        when(mockRest.postForEntity(anyString(), any(), any(Class.class)))
+            .thenReturn(ResponseEntity.ok(null));
+
+        VectorSearchResponse response = localService.search(new VectorSearchRequest(VECTOR, 5));
+
+        assertThat(response.getResults()).isEmpty();
+    }
+
+    // ── New tests: oversamplingFactor clamping ────────────────────────────────
+
+    @Test
+    void qdrantProperties_oversamplingFactor_defaultIs20() {
+        assertThat(new QdrantProperties().getOversamplingFactor()).isEqualTo(20);
+    }
+
+    @Test
+    void search_oversamplingFactor_greaterThan100_clampedToDefault20() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(150);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        RestTemplate rt = new RestTemplate();
+        MockRestServiceServer localServer = MockRestServiceServer.createServer(rt);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(rt, props, tmdb);
+
+        localServer.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(100)) // 5 * 20 (clamped)
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 5));
+
+        localServer.verify();
+    }
+
+    @Test
+    void search_oversamplingFactor_zero_clampedToDefault20() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(0);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        RestTemplate rt = new RestTemplate();
+        MockRestServiceServer localServer = MockRestServiceServer.createServer(rt);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(rt, props, tmdb);
+
+        localServer.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(100)) // 5 * 20 (clamped)
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 5));
+
+        localServer.verify();
+    }
+
+    @Test
+    void search_oversamplingFactor_negative_clampedToDefault20() {
+        QdrantProperties props = new QdrantProperties();
+        props.setBaseUrl(BASE_URL);
+        props.setOversamplingFactor(-1);
+        TmdbProperties tmdb = new TmdbProperties();
+        tmdb.setPosterBaseUrl(POSTER_BASE_URL);
+        RestTemplate rt = new RestTemplate();
+        MockRestServiceServer localServer = MockRestServiceServer.createServer(rt);
+        VectorSearchServiceImpl localService = new VectorSearchServiceImpl(rt, props, tmdb);
+
+        localServer.expect(requestTo(SEARCH_URL))
+            .andExpect(jsonPath("$.limit").value(100)) // 5 * 20 (clamped)
+            .andRespond(withSuccess("""
+                { "result": [] }
+                """, MediaType.APPLICATION_JSON));
+
+        localService.search(new VectorSearchRequest(VECTOR, 5));
+
+        localServer.verify();
     }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`QdrantProperties`**: adds `oversamplingFactor` field (default 20, config key `qdrant.oversampling-factor`); values outside 1–100 are clamped to 20 at runtime without failing startup
- **`MovieResult`**: adds nullable `matchingSegment` field
- **`VectorSearchServiceImpl`**: rewrites `search()` to fetch `limit × oversamplingFactor` chunks, group by `movie_id`, compute arithmetic mean score per movie, return up to `limit` distinct movies sorted by mean score descending; highest-scoring chunk text becomes `matchingSegment`; backwards-compat fallbacks (`chunk_text → summary_snippet`, `full_summary → summary_snippet`) keep the service operational against un-migrated Qdrant data; null `payload` and null `movie_id` chunks are silently skipped; null response body and null result array return empty list without throwing
- **`MockVectorSearchService`**: populates `matchingSegment` on all five hardcoded results
- **`VectorSearchServiceImplTest`**: existing tests updated (add `movie_id` to payloads, fix `$.limit` assertion to `limit × 20`); 15 new tests cover multi-chunk aggregation, oversampling factor multiplication, factor clamping (0 / −1 / >100 → 20), null body, null result array, null payload chunk, null `movie_id` chunk, result count capping, and old-schema fallback reads
- **`VectorSearchServiceImplIntegrationTest`**: adds `movie_id` to Qdrant mock payloads so existing integration tests pass with the new schema

Closes #270

## Test plan

- [x] `./mvnw -f api/pom.xml test -Dtest="VectorSearchServiceImplTest"` — 26 tests, all pass
- [x] `./mvnw -f api/pom.xml test -Dtest="VectorSearchServiceImplIntegrationTest"` — 4 tests, all pass
- [x] `./mvnw -f api/pom.xml test -Dtest="MockVectorSearchServiceTest,MockSearchServiceTest"` — 12 tests, all pass
- [x] All 42 affected tests: `BUILD SUCCESS`
- [x] Pre-existing `@SpringBootTest` context failures (`QdrantPropertiesTest`, `Feature5IntegrationTest`, etc.) are unrelated to this change — they fail on the baseline branch too due to missing ML model infrastructure (`HuggingFaceQueryTokenizer`)

https://claude.ai/code/session_01FGLAM9vrCm5uVfZBGhZJCH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGLAM9vrCm5uVfZBGhZJCH)_