### PR TITLE
Harden API and pipeline for public portfolio release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files
+* @atefft

--- a/.github/workflows/java-tests.yml
+++ b/.github/workflows/java-tests.yml
@@ -1,0 +1,32 @@
+name: Java Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: Maven Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run tests
+        run: ./mvnw -f api/pom.xml test
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: api/target/surefire-reports/

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,27 @@
+name: Python Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: Pytest
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r pipeline/requirements.txt
+
+      - name: Run tests
+        run: python3 -m pytest pipeline/tests/ -v

--- a/api/src/main/java/com/moviesearch/config/QdrantRestConfig.java
+++ b/api/src/main/java/com/moviesearch/config/QdrantRestConfig.java
@@ -2,6 +2,7 @@ package com.moviesearch.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,6 +10,9 @@ public class QdrantRestConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(10000);
+        return new RestTemplate(factory);
     }
 }

--- a/api/src/main/java/com/moviesearch/config/TritonGrpcConfig.java
+++ b/api/src/main/java/com/moviesearch/config/TritonGrpcConfig.java
@@ -19,6 +19,7 @@ public class TritonGrpcConfig {
     @Bean
     @ConditionalOnProperty(name = "triton.mock", havingValue = "false", matchIfMissing = true)
     public ManagedChannel tritonChannel(TritonProperties props) {
+        // Plaintext is intentional: Triton runs on the same Docker network with no external exposure
         channel = ManagedChannelBuilder.forAddress(props.getHost(), props.getPort())
                 .usePlaintext()
                 .build();

--- a/api/src/main/java/com/moviesearch/config/WebConfig.java
+++ b/api/src/main/java/com/moviesearch/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.moviesearch.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET")
+                .maxAge(3600);
+    }
+}

--- a/api/src/main/java/com/moviesearch/controller/SearchController.java
+++ b/api/src/main/java/com/moviesearch/controller/SearchController.java
@@ -31,7 +31,9 @@ public class SearchController {
             @RequestParam String q,
             @RequestParam(defaultValue = "10") int limit) {
 
-        if (q == null || q.isBlank()) {
+        q = q.strip();
+
+        if (q.isBlank()) {
             return ResponseEntity.badRequest().body(
                 ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,
                     "Query parameter 'q' must not be blank"));

--- a/pipeline/04_ingest_qdrant.py
+++ b/pipeline/04_ingest_qdrant.py
@@ -37,6 +37,11 @@ def main():
     with open("data/embeddings/metadata.json") as f:
         metadata = json.load(f)
 
+    if len(embeddings) != len(metadata):
+        raise ValueError(
+            f"Embedding count ({len(embeddings)}) != metadata count ({len(metadata)})"
+        )
+
     client = QdrantClient(url=args.qdrant_url)
     setup_collection(client, "movies")
     points = build_points(embeddings, metadata)


### PR DESCRIPTION
## Summary

- **RestTemplate timeouts**: Add 5s connect / 10s read timeout via `SimpleClientHttpRequestFactory` — prevents Qdrant hangs from blocking threads indefinitely
- **CORS config**: New `WebConfig` allows `GET /api/**` from any origin, making the API usable from any frontend without browser errors
- **Query normalization**: Strip leading/trailing whitespace from `q` before validation so `"  batman  "` and `"batman"` are treated identically
- **Pipeline guard**: Fail fast in `04_ingest_qdrant.py` if embedding and metadata counts don't match, rather than silently ingesting mismatched data
- **gRPC comment**: Document that `.usePlaintext()` is intentional (same Docker network, no external exposure)
- **CODEOWNERS**: Add `.github/CODEOWNERS` assigning `@atefft` as default reviewer on all files
- **CI workflows**: Add `java-tests.yml` (Maven) and `python-tests.yml` (pytest) so PRs run the full test suite — not just the Docker Compose startup check

## Test plan

- [x] `mvn test` — 216 tests, 0 failures
- [x] `pytest pipeline/tests/` — 78 unit tests pass (Docker integration test failures are pre-existing and require a built pipeline image)
- [ ] Set branch protection on `main` in GitHub Settings: require PR + status checks (java-tests, python-tests, startup-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)