### PR TITLE
Fix disk space prerequisite: ~25 GB not ~4 GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ movie-semantic-search/
 
 ### To run the project
 - **Docker Desktop** 4.x+ (with Compose v2)
-- ~4 GB disk space for corpus + model + vectors
+- **~25 GB free disk space** — the Triton Inference Server image alone is ~23 GB; corpus + model + vectors add ~500 MB on top
 
 ### To develop or run tests locally
 - **Python 3.11+** with pip (pipeline tests)


### PR DESCRIPTION
## Summary

- The Triton Inference Server image (`nvcr.io/nvidia/tritonserver:24.01-py3`) is ~23 GB on its own
- The previous ~4 GB estimate only counted corpus + model + vector files, missing all Docker images entirely
- Updated to ~25 GB with a note explaining where the bulk of it comes from

🤖 Generated with [Claude Code](https://claude.com/claude-code)